### PR TITLE
Add hasOwnProperty

### DIFF
--- a/blns.base64.json
+++ b/blns.base64.json
@@ -12,6 +12,7 @@
      "VHJ1ZQo=",
      "RmFsc2UK",
      "Tm9uZQo=",
+     "aGFzT3duUHJvcGVydHkK",
      "XFw=",
      "MAo=",
      "XFxcXAo=",

--- a/blns.base64.txt
+++ b/blns.base64.txt
@@ -14,6 +14,7 @@ ZmFsc2UK
 VHJ1ZQo=
 RmFsc2UK
 Tm9uZQo=
+aGFzT3duUHJvcGVydHkK
 XAo=
 
 # Numeric Strings

--- a/blns.json
+++ b/blns.json
@@ -12,6 +12,7 @@
   "True", 
   "False", 
   "None", 
+  "hasOwnProperty", 
   "\\", 
   "\\\\", 
   "0", 

--- a/blns.txt
+++ b/blns.txt
@@ -14,6 +14,7 @@ false
 True
 False
 None
+hasOwnProperty
 \
 \\
 


### PR DESCRIPTION
It’s common in JavaScript to use input as a key in an object and check for the existence of keys using `obj.hasOwnProperty(key)` instead of `Object.prototype.hasOwnProperty.call(obj, key)`.