### PR TITLE
Remove trailing \n from texttobase64.sh

### DIFF
--- a/scripts/texttobase64.sh
+++ b/scripts/texttobase64.sh
@@ -2,7 +2,7 @@ commentChar="#"
 while read p; do 
         firstChar=${p:0:1}
         if [[ "$firstChar" != "$commentChar" && "$firstChar" != "" ]] ; then
-		echo $p | base64; 
+		echo -n $p | base64;
 	else
 		echo $p;
 	fi


### PR DESCRIPTION
Without this, all base64 strings will get a trailing \n in their encoded form

ref #86

Does *not* update the `blns.base64.txt` file