### PR TITLE
Year should be year of original publication

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Max Woolf
+Copyright (c) 2015 Max Woolf
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Great project! Thanks for this.

While looking through it I noticed that you've updated the copyright year to 2017 but actually, the aim of the year in a copyright notice is to indicate when the work was originally published, in case of any dispute. So I thought I'd raise a PR.

You're not in the UK but this, from the UK's copyright service is useful: http://www.copyrightservice.co.uk/copyright/p03_copyright_notices, item 4, and the rules will be the same in the US.