### PR TITLE
Remove EICAR statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Although this is not a malicious error, and typical users aren't Tweeting weird 
 
 Feel free to send a pull request to add more strings, or additional sections. However, please do not send pull requests with very-long strings (255+ characters), as that makes the list much more difficult to view.
 
-Likewise, please do not send pull requests which compromise *manual usability of the file*. This includes the [EICAR test string](https://en.wikipedia.org/wiki/EICAR_test_file), which can cause the file to be flagged by antivirus scanners, and files which alter the encoding of `blns.txt`. Also, do not send a null character (U+0000) string, as it [changes the file format on GitHub to binary](http://stackoverflow.com/a/19723302) and renders it unreadable in pull requests. Finally, when adding or removing a string please update all files when you perform a pull request.
+Likewise, please do not send pull requests which compromise *manual usability of the file*; this includes files which alter the encoding of `blns.txt`. Also, do not send a null character (U+0000) string, as it [changes the file format on GitHub to binary](http://stackoverflow.com/a/19723302) and renders it unreadable in pull requests. Finally, when adding or removing a string please update all files when you perform a pull request.
 
 ## Disclaimer
 


### PR DESCRIPTION
The EICAR string is in the `blns`, no need for it to be contradicted in the README.
See #111 