### PR TITLE
Fix "On Testing" URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Big List of Naughty Strings
-The Big List of Naughty Strings is an evolving list of strings which have a high probability of causing issues when used as user-input data. This is intended for use in helping both automated and manual QA testing; useful for whenever your QA engineer [walks into a bar](http://www.sempf.net/post/On-Testing1.aspx).
+The Big List of Naughty Strings is an evolving list of strings which have a high probability of causing issues when used as user-input data. This is intended for use in helping both automated and manual QA testing; useful for whenever your QA engineer [walks into a bar](http://www.sempf.net/post/On-Testing1).
 
 ## Why Test Naughty Strings?
 


### PR DESCRIPTION
The "On Testing" link in the first paragraph of the README doesn't
work, because the owner of that web page has moved it to a different
URL without the file extension, without setting up a redirect.

This commit fixes the URL so it goes to the page for which it is
intended.