### PR TITLE
Add "then" to strings which may be used elsewhere

### DIFF
--- a/blns.txt
+++ b/blns.txt
@@ -17,6 +17,7 @@ TRUE
 FALSE
 None
 hasOwnProperty
+then
 \
 \\
 


### PR DESCRIPTION
The massive adoption of Promises (and introduction of `async`/`await` based on them) in JavaScript made many programs potentially vulnerable to "accidental Promises".

In short, a program might take user input and produce an object as such:

```js
{
  [userInput]: AnyFunction
}
```

...when the object above is given to a Promise (by returning it from `then`, calling `Promise.resolve`, passing it into `res` or `rej` when constructing a `new Promise`, or awaiting/returning it from an `async` function), everything will seem fine **unless the input is exactly `"then"`**. Once it's *then*, a Promise will assume that the object is another Promise, and in trying to assimilate this accidental Promise the function will be called. After that, one of three things will happen depending on what the `AnyFunction` does with its input:

1. The function calls one of the continuations provided by the Promise, and the program continues with some unexpected data (this is highly unlikely)
1. The program hangs and never terminates (if the function stores input in memory)
1. The program terminates early, failing to execute any other chained Promises (the more likely case)

For more in-depth information, please refer to the appropriate sections in the articles I've written regarding this issue:

1. [Broken Promises - Specialized API](https://medium.com/@avaq/broken-promises-2ae92780f33#6828)
1. [A clarification with examples to the article above](https://medium.com/@avaq/im-referring-to-the-fact-that-a-promise-is-eagerly-evaluated-as-opposed-to-lazily-evaluated-5385cc519e3b#33cd) (see the part under "I never found myself creating an object with a then method")