### PR TITLE
update blns to account for more format strings

### DIFF
--- a/blns.txt
+++ b/blns.txt
@@ -588,9 +588,11 @@ Kernel.exit(1)
 $HOME
 $ENV{'HOME'}
 %d
-%s
+%s%s%s%s%s
 {0}
 %*.*s
+%@
+%n
 File:///
 
 #	File Inclusion


### PR DESCRIPTION
Made a couple of changes to the format strings:
- added more %s'. increases the chance of crashing. Sometimes the stack layout is just right and 1 or 2 %s will not cause a crash 
- added %n. Should cause a crash, even if several other specifiers don't
- added %@, this is for objective-c format functions.