### PR TITLE
Updating scripts/txt_to_json.py to run with guard

### DIFF
--- a/scripts/txt_to_json.py
+++ b/scripts/txt_to_json.py
@@ -4,25 +4,27 @@
 
 import json
 
-with open('../blns.txt', 'r') as f:
+def txt_to_json():
+    with open('../blns.txt', 'r') as f:
 
-    # put all lines in the file into a Python list
-    content = f.readlines()
+        # put all lines in the file into a Python list
+        content = f.readlines()
     
-    # above line leaves trailing newline characters; strip them out
-    content = [x.strip('\n') for x in content]
+        # above line leaves trailing newline characters; strip them out
+        content = [x.strip('\n') for x in content]
     
-    # remove empty-lines and comments
-    content = [x for x in content if x and not x.startswith('#')]
+        # remove empty-lines and comments
+        content = [x for x in content if x and not x.startswith('#')]
     
-    # insert empty string since all are being removed
-    content.insert(0, "")
+        # insert empty string since all are being removed
+        content.insert(0, "")
     
-    # special case: convert "\" to "\\" for valid JSON
-    #content = map(lambda x: x.replace('\','\\'), content)
+        # special case: convert "\" to "\\" for valid JSON
+        # content = map(lambda x: x.replace('\','\\'), content)
     
-with open('../blns.json', 'wb') as f:
+    with open('../blns.json', 'wb') as f:
+        # write JSON to file; note the ensure_ascii parameter
+        json.dump(content, f, indent=2, ensure_ascii=False)
 
-	# write JSON to file; note the ensure_ascii parameter
-	json.dump(content, f, indent=2, ensure_ascii=False)
-    
+if __name__ == '__main__':
+	txt_to_json()


### PR DESCRIPTION
Python scripts should run 'guarded', meaning that they only execute when you intend, and not when importing or scanning (like when executing doctests).

This can cause issues if people bring blns into their repo as a submodule, as things like test runners or doctest runners will have to manually exclude this file when they are running, which is inconvenient.

[This stack overflow answer](https://stackoverflow.com/questions/5544752/should-i-use-a-main-method-in-a-simple-python-script/5544937) gives more detail on why this is important.

p.s. this script doesn't actually work for me, does it have tests somewhere?