### PR TITLE
introduce makefile to generate internal/resource.go

### DIFF
--- a/naughtystrings/Makefile
+++ b/naughtystrings/Makefile
@@ -1,0 +1,3 @@
+# Uses https://github.com/go-bindata/go-bindata
+naughtystrings/internal/resource.go:
+	go-bindata -o internal/resource.go -pkg internal -nocompress ../blns*.json


### PR DESCRIPTION
We struggled to work out how `resource.go` was made. After a bit of digging, we figured out how to do it with https://github.com/go-bindata/go-bindata.