### PR TITLE
Adds `constructor`

### DIFF
--- a/blns.txt
+++ b/blns.txt
@@ -18,6 +18,7 @@ FALSE
 None
 hasOwnProperty
 then
+constructor
 \
 \\
 


### PR DESCRIPTION
`constructor` is the only lowercase identifier that is `in` all JavaScript objects, and can be involved in obscure XSS so can be used to abuse code that uses JavaScript objects as lookup tables.

```js
var empty = {};
if ('constuctor' in empty && empty['constructor']) {
  // runs
}
empty['constructor']['constructor']('alert(1)')();  // Parses and runs 
```