### PR TITLE
Add EICAR test file

### DIFF
--- a/blns.txt
+++ b/blns.txt
@@ -740,3 +740,11 @@ Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗
 
 {% print 'x' * 64 * 1024**3 %}
 {{ "".__class__.__mro__[2].__subclasses__()[40]("/etc/passwd").read() }}
+
+# EICAR "anti-virus test string"
+#
+# A surprising amount of systems will fail when presented with the EICAR test
+# string, which is used to "test" anti-virus engines as working (i.e., as
+# opposed to downloading malware samples and seeing if they're detected)
+
+X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*


### PR DESCRIPTION
A surprising amount of systems will fail in unique and unexpected ways
when presented with the EICAR test string. While its intentions were
noble, its simple detection sequence can lead to systems
being "poisoned" with it. Virus scanners that "actively scan" for
malware may detect the EICAR test string inside objects, including
memory space of protected applications, stored data on disk (such as
inside databases), over network transmissions, etc.

The real world implications of the test string's pitfalls are easy to
understand. For example, it is common for companies to "require"
antivirus software to be placed on critical servers and other systems
that normally house user data. Thus, it may be possible perform a
denial of service simply by presenting vulnerable systems with the
EICAR test string. Even when servers are not scanned, it is still
possible for user input to be displayed in unexpected contexts. For
example, a customer service back-end panel might offer CSV export
downloads of material for analysis. Or the user input may be displayed
in a browser window visible to a CS agent. In all of these contexts, an
antivirus tool may take corrective action that results in rendering one
or more systems temporarily inaccessible, or worse.