### PR TITLE
Add Rust library

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Various implementations of the Big List of Naughty Strings have made it to vario
 | .NET | https://github.com/SimonCropp/NaughtyStrings |
 | PHP | https://github.com/mattsparks/blns-php |
 | C++  | https://github.com/eliabieri/blnscpp |
+| Rust | https://github.com/mcarton/rust-naughty-strings |
 
 Please open a PR to list others.
 


### PR DESCRIPTION
This pull request adds the rust library [rust-naughty-strings](https://github.com/mcarton/rust-naughty-strings) to the readme. 