### PR TITLE
Update blns.txt

### DIFF
--- a/blns.txt
+++ b/blns.txt
@@ -231,6 +231,12 @@ INF
 Ⱥ
 Ⱦ
 
+#	Changing length when uppercased
+#
+#	The German character 'ß' becomes 'SS' when upper-cased, which becomes 'ss' when lower-cased
+
+ß
+
 #	Japanese Emoticons
 #
 #	Strings which consists of Japanese-style emoticons which are popular on the web


### PR DESCRIPTION
added German character ß, which becomes 'SS' when upper-cased, so changes from one character to two ascii characters

Note that a upper-lower-case round-trip is now impossible: "ß".upper().lower() -> "ss"